### PR TITLE
Build with rust stable and beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: rust
 sudo: false
 
 rust:
+  - stable
+  - beta
   - nightly
 
 script:        scripts/build.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ keywords = ["yaml", "serde"]
 [dependencies]
 clippy = { version = "^0.*", optional = true }
 serde = "^0.7"
-serde_macros = "^0.7"
 yaml-rust = "^0.3"
+
+[dev-dependencies]
+serde_macros = "^0.7"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,10 +5,12 @@
 
 set -ex
 
-cargo build --features clippy --verbose
-
-cargo test --features clippy --verbose
-
 if [ "$TRAVIS_RUST_VERSION" = nightly ]; then
+    cargo build --features clippy --verbose
+
+    cargo test --features clippy --verbose
+
     cargo doc --verbose
+else
+    cargo build --verbose
 fi


### PR DESCRIPTION
The main caveat of this pull request is tests for stable and beta cannot be run due to relying on `serde_marco`, it might be worth looking into how the [serde/json](https://github.com/serde-rs/json) run their tests for stable and beta.

Solves Issue #1 