### PR TITLE
Preserve order of map keys

### DIFF
--- a/yaml/Cargo.toml
+++ b/yaml/Cargo.toml
@@ -9,7 +9,10 @@ documentation = "https://dtolnay.github.io/serde-yaml/"
 readme = "../README.md"
 keywords = ["yaml", "serde"]
 
+[features]
+preserve_order = ["yaml-rust/preserve_order"]
+
 [dependencies]
 clippy = { version = "^0.*", optional = true }
 serde = "^0.7"
-yaml-rust = "^0.3"
+yaml-rust = "^0.3.2"


### PR DESCRIPTION
This is blocked on the following PRs and releases:

- [x] https://github.com/contain-rs/linked-hash-map/pull/48
- [x] [0.0.10 release of linked-hash-map](https://crates.io/crates/linked-hash-map/0.0.10)
- [x] https://github.com/chyh1990/yaml-rust/pull/16
- [x] [0.3.2 release of yaml-rust](https://crates.io/crates/yaml-rust/0.3.2)