### PR TITLE
Formatted error messages created by other libraries no longer get overridden

### DIFF
--- a/yaml/src/error.rs
+++ b/yaml/src/error.rs
@@ -76,13 +76,13 @@ impl fmt::Display for Error {
             Error::Emit(ref err) =>
                 write!(f, "{:?}", err),
             Error::Scan(ref err) =>
-                write!(f, "{:?}", err),
+                err.fmt(f),
             Error::Io(ref err) =>
-                write!(f, "{:?}", err),
+                err.fmt(f),
             Error::Utf8(ref err) =>
-                write!(f, "{:?}", err),
+                err.fmt(f),
             Error::FromUtf8(ref err) =>
-                write!(f, "{:?}", err),
+                err.fmt(f),
             Error::AliasUnsupported =>
                 write!(f, "YAML aliases are not supported"),
             Error::TooManyDocuments(n) =>

--- a/yaml_tests/tests/test_error.rs
+++ b/yaml_tests/tests/test_error.rs
@@ -54,14 +54,7 @@ fn test_unknown_anchor() {
         ---
         *some");
     let expected =
-        "ScanError { \
-          mark: Marker { \
-            index: 4, \
-            line: 2, \
-            col: 0 \
-          }, \
-          info: \"while parsing node, found unknown anchor\" \
-        }";
+        "while parsing node, found unknown anchor at line 2 column 1";
     test_error::<String>(yaml, expected);
 }
 


### PR DESCRIPTION
Fixes #17 