### PR TITLE
Implement {S,Des}erialize for Mapping

### DIFF
--- a/yaml/src/lib.rs
+++ b/yaml/src/lib.rs
@@ -17,11 +17,13 @@ extern crate yaml_rust;
 
 pub use self::de::{from_iter, from_reader, from_slice, from_str};
 pub use self::ser::{to_string, to_vec, to_writer};
-pub use self::value::{Mapping, Sequence, Value, from_value, to_value};
+pub use self::value::{Sequence, Value, from_value, to_value};
 pub use self::error::{Error, Result};
+pub use self::mapping::Mapping;
 
 mod de;
 mod ser;
 mod value;
 mod error;
 mod path;
+mod mapping;

--- a/yaml/src/mapping.rs
+++ b/yaml/src/mapping.rs
@@ -1,0 +1,172 @@
+// Copyright 2016 Serde YAML Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt;
+use std::iter::FromIterator;
+use std::ops::{Index, IndexMut};
+
+use linked_hash_map::{self, LinkedHashMap};
+use serde::{self, Serialize, Deserialize, Deserializer};
+
+use value::Value;
+
+/// A YAML mapping in which the keys and values are both `serde_yaml::Value`.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
+pub struct Mapping {
+    map: LinkedHashMap<Value, Value>,
+}
+
+impl Mapping {
+    #[inline]
+    pub fn new() -> Self { Self::default() }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Mapping {
+            map: LinkedHashMap::with_capacity(capacity),
+        }
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) { self.map.reserve(additional) }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) { self.map.shrink_to_fit() }
+
+    #[inline]
+    pub fn insert(&mut self, k: Value, v: Value) -> Option<Value> { self.map.insert(k, v) }
+
+    #[inline]
+    pub fn contains_key(&self, k: &Value) -> bool { self.map.contains_key(k) }
+
+    #[inline]
+    pub fn get(&self, k: &Value) -> Option<&Value> { self.map.get(k) }
+
+    #[inline]
+    pub fn get_mut(&mut self, k: &Value) -> Option<&mut Value> { self.map.get_mut(k) }
+
+    #[inline]
+    pub fn remove(&mut self, k: &Value) -> Option<Value> { self.map.remove(k) }
+
+    #[inline]
+    pub fn capacity(&self) -> usize { self.map.capacity() }
+
+    #[inline]
+    pub fn len(&self) -> usize { self.map.len() }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.map.is_empty() }
+
+    #[inline]
+    pub fn clear(&mut self) { self.map.clear() }
+
+    #[inline]
+    pub fn iter(&self) -> linked_hash_map::Iter<Value, Value> { self.map.iter() }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
+}
+
+impl<'a> Index<&'a Value> for Mapping {
+    type Output = Value;
+    #[inline]
+    fn index(&self, index: &'a Value) -> &Value {
+        self.map.index(index)
+    }
+}
+
+impl<'a> IndexMut<&'a Value> for Mapping {
+    #[inline]
+    fn index_mut(&mut self, index: &'a Value) -> &mut Value {
+        self.map.index_mut(index)
+    }
+}
+
+impl Extend<(Value, Value)> for Mapping {
+    #[inline]
+    fn extend<I: IntoIterator<Item=(Value, Value)>>(&mut self, iter: I) {
+        self.map.extend(iter);
+    }
+}
+
+impl FromIterator<(Value, Value)> for Mapping {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item=(Value, Value)>>(iter: I) -> Self {
+        Mapping {
+            map: LinkedHashMap::from_iter(iter)
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Mapping {
+    type Item = (&'a Value, &'a Value);
+    type IntoIter = linked_hash_map::Iter<'a, Value, Value>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.map.iter() }
+}
+
+impl<'a> IntoIterator for &'a mut Mapping {
+    type Item = (&'a Value, &'a mut Value);
+    type IntoIter = linked_hash_map::IterMut<'a, Value, Value>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.map.iter_mut() }
+}
+
+impl IntoIterator for Mapping {
+    type Item = (Value, Value);
+    type IntoIter = linked_hash_map::IntoIter<Value, Value>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
+}
+
+impl Serialize for Mapping {
+    #[inline]
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map_serializer = try!(serializer.serialize_map(Some(self.len())));
+        for (k, v) in self {
+            try!(map_serializer.serialize_key(k));
+            try!(map_serializer.serialize_value(v));
+        }
+        map_serializer.end()
+    }
+}
+
+impl Deserialize for Mapping {
+    fn deserialize<D: Deserializer>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+
+        impl serde::de::Visitor for Visitor {
+            type Value = Mapping;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a YAML mapping")
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where E: serde::de::Error
+            {
+                Ok(Mapping::new())
+            }
+
+            #[inline]
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+                where V: serde::de::MapVisitor
+            {
+                let mut values = Mapping::with_capacity(visitor.size_hint().0);
+                while let Some((k, v)) = try!(visitor.visit()) {
+                    values.insert(k, v);
+                }
+                Ok(values)
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}

--- a/yaml/src/mapping.rs
+++ b/yaml/src/mapping.rs
@@ -66,10 +66,10 @@ impl Mapping {
     pub fn clear(&mut self) { self.map.clear() }
 
     #[inline]
-    pub fn iter(&self) -> linked_hash_map::Iter<Value, Value> { self.map.iter() }
+    pub fn iter(&self) -> Iter { Iter { iter: self.map.iter() } }
 
     #[inline]
-    pub fn iter_mut(&mut self) -> linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
+    pub fn iter_mut(&mut self) -> IterMut { IterMut { iter: self.map.iter_mut() } }
 }
 
 impl<'a> Index<&'a Value> for Mapping {

--- a/yaml/src/value.rs
+++ b/yaml/src/value.rs
@@ -113,6 +113,19 @@ impl IntoIterator for Mapping {
     fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
 }
 
+impl Serialize for Mapping {
+    #[inline]
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map_serializer = try!(serializer.serialize_map(Some(self.len())));
+        for (k, v) in self {
+            try!(map_serializer.serialize_key(k));
+            try!(map_serializer.serialize_value(v));
+        }
+        map_serializer.end()
+    }
+}
+
 impl Deserialize for Mapping {
     fn deserialize<D: Deserializer>(deserializer: D) -> Result<Self, D::Error> {
         struct Visitor;

--- a/yaml/src/value.rs
+++ b/yaml/src/value.rs
@@ -63,10 +63,43 @@ impl Mapping {
     }
 
     #[inline]
-    pub fn len(&self) -> usize { self.map.len() }
+    pub fn reserve(&mut self, additional: usize) { self.map.reserve(additional) }
+
+    #[inline]
+    pub fn shrink_to_fit(&mut self) { self.map.shrink_to_fit() }
 
     #[inline]
     pub fn insert(&mut self, k: Value, v: Value) -> Option<Value> { self.map.insert(k, v) }
+
+    #[inline]
+    pub fn contains_key(&self, k: &Value) -> bool { self.map.contains_key(k) }
+
+    #[inline]
+    pub fn get(&self, k: &Value) -> Option<&Value> { self.map.get(k) }
+
+    #[inline]
+    pub fn get_mut(&mut self, k: &Value) -> Option<&mut Value> { self.map.get_mut(k) }
+
+    #[inline]
+    pub fn remove(&mut self, k: &Value) -> Option<Value> { self.map.remove(k) }
+
+    #[inline]
+    pub fn capacity(&self) -> usize { self.map.capacity() }
+
+    #[inline]
+    pub fn len(&self) -> usize { self.map.len() }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.map.is_empty() }
+
+    #[inline]
+    pub fn clear(&mut self) { self.map.clear() }
+
+    #[inline]
+    pub fn iter(&self) -> ::linked_hash_map::Iter<Value, Value> { self.map.iter() }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> ::linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
 }
 
 impl<'a> Index<&'a Value> for Mapping {

--- a/yaml/src/value.rs
+++ b/yaml/src/value.rs
@@ -13,7 +13,7 @@ use std::mem;
 use std::ops::{Index, IndexMut};
 use std::vec;
 
-use linked_hash_map::LinkedHashMap;
+use linked_hash_map::{self, LinkedHashMap};
 use serde::{self, Serialize, Deserialize, Deserializer};
 use serde::de::{Unexpected, Visitor};
 use yaml_rust::Yaml;
@@ -96,10 +96,10 @@ impl Mapping {
     pub fn clear(&mut self) { self.map.clear() }
 
     #[inline]
-    pub fn iter(&self) -> ::linked_hash_map::Iter<Value, Value> { self.map.iter() }
+    pub fn iter(&self) -> linked_hash_map::Iter<Value, Value> { self.map.iter() }
 
     #[inline]
-    pub fn iter_mut(&mut self) -> ::linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
+    pub fn iter_mut(&mut self) -> linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
 }
 
 impl<'a> Index<&'a Value> for Mapping {
@@ -135,21 +135,21 @@ impl FromIterator<(Value, Value)> for Mapping {
 
 impl<'a> IntoIterator for &'a Mapping {
     type Item = (&'a Value, &'a Value);
-    type IntoIter = ::linked_hash_map::Iter<'a, Value, Value>;
+    type IntoIter = linked_hash_map::Iter<'a, Value, Value>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.iter() }
 }
 
 impl<'a> IntoIterator for &'a mut Mapping {
     type Item = (&'a Value, &'a mut Value);
-    type IntoIter = ::linked_hash_map::IterMut<'a, Value, Value>;
+    type IntoIter = linked_hash_map::IterMut<'a, Value, Value>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.iter_mut() }
 }
 
 impl IntoIterator for Mapping {
     type Item = (Value, Value);
-    type IntoIter = ::linked_hash_map::IntoIter<Value, Value>;
+    type IntoIter = linked_hash_map::IntoIter<Value, Value>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
 }

--- a/yaml/src/value.rs
+++ b/yaml/src/value.rs
@@ -8,17 +8,15 @@
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::mem;
-use std::ops::{Index, IndexMut};
 use std::vec;
 
-use linked_hash_map::{self, LinkedHashMap};
 use serde::{self, Serialize, Deserialize, Deserializer};
 use serde::de::{Unexpected, Visitor};
 use yaml_rust::Yaml;
 
 use error::Error;
+use mapping::Mapping;
 use ser::Serializer;
 
 /// Represents any valid YAML value.
@@ -44,162 +42,6 @@ pub enum Value {
 
 /// A YAML sequence in which the elements are `serde_yaml::Value`.
 pub type Sequence = Vec<Value>;
-
-/// A YAML mapping in which the keys and values are both `serde_yaml::Value`.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
-pub struct Mapping {
-    map: LinkedHashMap<Value, Value>,
-}
-
-impl Mapping {
-    #[inline]
-    pub fn new() -> Self { Self::default() }
-
-    #[inline]
-    pub fn with_capacity(capacity: usize) -> Self {
-        Mapping {
-            map: LinkedHashMap::with_capacity(capacity),
-        }
-    }
-
-    #[inline]
-    pub fn reserve(&mut self, additional: usize) { self.map.reserve(additional) }
-
-    #[inline]
-    pub fn shrink_to_fit(&mut self) { self.map.shrink_to_fit() }
-
-    #[inline]
-    pub fn insert(&mut self, k: Value, v: Value) -> Option<Value> { self.map.insert(k, v) }
-
-    #[inline]
-    pub fn contains_key(&self, k: &Value) -> bool { self.map.contains_key(k) }
-
-    #[inline]
-    pub fn get(&self, k: &Value) -> Option<&Value> { self.map.get(k) }
-
-    #[inline]
-    pub fn get_mut(&mut self, k: &Value) -> Option<&mut Value> { self.map.get_mut(k) }
-
-    #[inline]
-    pub fn remove(&mut self, k: &Value) -> Option<Value> { self.map.remove(k) }
-
-    #[inline]
-    pub fn capacity(&self) -> usize { self.map.capacity() }
-
-    #[inline]
-    pub fn len(&self) -> usize { self.map.len() }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool { self.map.is_empty() }
-
-    #[inline]
-    pub fn clear(&mut self) { self.map.clear() }
-
-    #[inline]
-    pub fn iter(&self) -> linked_hash_map::Iter<Value, Value> { self.map.iter() }
-
-    #[inline]
-    pub fn iter_mut(&mut self) -> linked_hash_map::IterMut<Value, Value> { self.map.iter_mut() }
-}
-
-impl<'a> Index<&'a Value> for Mapping {
-    type Output = Value;
-    #[inline]
-    fn index(&self, index: &'a Value) -> &Value {
-        self.map.index(index)
-    }
-}
-
-impl<'a> IndexMut<&'a Value> for Mapping {
-    #[inline]
-    fn index_mut(&mut self, index: &'a Value) -> &mut Value {
-        self.map.index_mut(index)
-    }
-}
-
-impl Extend<(Value, Value)> for Mapping {
-    #[inline]
-    fn extend<I: IntoIterator<Item=(Value, Value)>>(&mut self, iter: I) {
-        self.map.extend(iter);
-    }
-}
-
-impl FromIterator<(Value, Value)> for Mapping {
-    #[inline]
-    fn from_iter<I: IntoIterator<Item=(Value, Value)>>(iter: I) -> Self {
-        Mapping {
-            map: LinkedHashMap::from_iter(iter)
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a Mapping {
-    type Item = (&'a Value, &'a Value);
-    type IntoIter = linked_hash_map::Iter<'a, Value, Value>;
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter { self.map.iter() }
-}
-
-impl<'a> IntoIterator for &'a mut Mapping {
-    type Item = (&'a Value, &'a mut Value);
-    type IntoIter = linked_hash_map::IterMut<'a, Value, Value>;
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter { self.map.iter_mut() }
-}
-
-impl IntoIterator for Mapping {
-    type Item = (Value, Value);
-    type IntoIter = linked_hash_map::IntoIter<Value, Value>;
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
-}
-
-impl Serialize for Mapping {
-    #[inline]
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeMap;
-        let mut map_serializer = try!(serializer.serialize_map(Some(self.len())));
-        for (k, v) in self {
-            try!(map_serializer.serialize_key(k));
-            try!(map_serializer.serialize_value(v));
-        }
-        map_serializer.end()
-    }
-}
-
-impl Deserialize for Mapping {
-    fn deserialize<D: Deserializer>(deserializer: D) -> Result<Self, D::Error> {
-        struct Visitor;
-
-        impl serde::de::Visitor for Visitor {
-            type Value = Mapping;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a YAML mapping")
-            }
-
-            #[inline]
-            fn visit_unit<E>(self) -> Result<Self::Value, E>
-                where E: serde::de::Error
-            {
-                Ok(Mapping::new())
-            }
-
-            #[inline]
-            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-                where V: serde::de::MapVisitor
-            {
-                let mut values = Mapping::with_capacity(visitor.size_hint().0);
-                while let Some((k, v)) = try!(visitor.visit()) {
-                    values.insert(k, v);
-                }
-                Ok(values)
-            }
-        }
-
-        deserializer.deserialize_map(Visitor)
-    }
-}
 
 /// Convert a `T` into `serde_yaml::Value` which is an enum that can represent
 /// any valid YAML data.

--- a/yaml/src/value.rs
+++ b/yaml/src/value.rs
@@ -52,39 +52,47 @@ pub struct Mapping {
 }
 
 impl Mapping {
+    #[inline]
     pub fn new() -> Self { Self::default() }
 
+    #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Mapping {
             map: LinkedHashMap::with_capacity(capacity),
         }
     }
 
+    #[inline]
     pub fn len(&self) -> usize { self.map.len() }
 
+    #[inline]
     pub fn insert(&mut self, k: Value, v: Value) -> Option<Value> { self.map.insert(k, v) }
 }
 
 impl<'a> Index<&'a Value> for Mapping {
     type Output = Value;
+    #[inline]
     fn index(&self, index: &'a Value) -> &Value {
         self.map.index(index)
     }
 }
 
 impl<'a> IndexMut<&'a Value> for Mapping {
+    #[inline]
     fn index_mut(&mut self, index: &'a Value) -> &mut Value {
         self.map.index_mut(index)
     }
 }
 
 impl Extend<(Value, Value)> for Mapping {
+    #[inline]
     fn extend<I: IntoIterator<Item=(Value, Value)>>(&mut self, iter: I) {
         self.map.extend(iter);
     }
 }
 
 impl FromIterator<(Value, Value)> for Mapping {
+    #[inline]
     fn from_iter<I: IntoIterator<Item=(Value, Value)>>(iter: I) -> Self {
         Mapping {
             map: LinkedHashMap::from_iter(iter)
@@ -95,21 +103,21 @@ impl FromIterator<(Value, Value)> for Mapping {
 impl<'a> IntoIterator for &'a Mapping {
     type Item = (&'a Value, &'a Value);
     type IntoIter = ::linked_hash_map::Iter<'a, Value, Value>;
-
+    #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.iter() }
 }
 
 impl<'a> IntoIterator for &'a mut Mapping {
     type Item = (&'a Value, &'a mut Value);
     type IntoIter = ::linked_hash_map::IterMut<'a, Value, Value>;
-
+    #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.iter_mut() }
 }
 
 impl IntoIterator for Mapping {
     type Item = (Value, Value);
     type IntoIter = ::linked_hash_map::IntoIter<Value, Value>;
-
+    #[inline]
     fn into_iter(self) -> Self::IntoIter { self.map.into_iter() }
 }
 

--- a/yaml_tests/tests/test_de.rs
+++ b/yaml_tests/tests/test_de.rs
@@ -154,3 +154,28 @@ fn test_number_as_string() {
     };
     test_de(yaml, expected);
 }
+
+#[test]
+fn test_de_mapping() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Data {
+        pub substructure: serde_yaml::Mapping,
+    }
+    let yaml = indoc!("
+        ---
+        substructure:
+          a: 'foo'
+          b: 'bar'");
+
+    let mut expected = Data {
+        substructure: serde_yaml::Mapping::new(),
+    };
+    expected.substructure.insert(
+        serde_yaml::Value::String("a".to_owned()),
+        serde_yaml::Value::String("foo".to_owned()));
+    expected.substructure.insert(
+        serde_yaml::Value::String("b".to_owned()),
+        serde_yaml::Value::String("bar".to_owned()));
+
+    test_de(yaml, expected);
+}

--- a/yaml_tests/tests/test_serde.rs
+++ b/yaml_tests/tests/test_serde.rs
@@ -289,3 +289,28 @@ fn test_value() {
           - {}"#);
     test_serde(thing, yaml);
 }
+
+#[test]
+fn test_mapping() {
+    use serde_yaml::{Mapping, Value};
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Data {
+        pub substructure: Mapping,
+    }
+
+    let mut thing = Data {
+        substructure: Mapping::new(),
+    };
+    thing.substructure.insert(
+        Value::String("a".to_owned()), Value::String("foo".to_owned()));
+    thing.substructure.insert(
+        Value::String("b".to_owned()), Value::String("bar".to_owned()));
+
+    let yaml = indoc!("
+        ---
+        substructure: 
+          a: foo
+          b: bar");
+
+    test_serde(thing, yaml);
+}


### PR DESCRIPTION
Fixes #46.

There are a couple of things that might be interesting to think about here before merging:

- Mapping isn't fully compatible with LinkedHashMap. In some cases, this is intentional: e.g. by not implementing pop_front() and pop_back() we retain the flexibility to switch to another non-ordered map implementation in the future. But, this does mean that serde-yaml users may need to modify their code after this change.
- We're still leaking some parts of the linked_hash_map API (e.g., iterator types).
- Maybe we should move Mapping to "mapping.rs" instead, to avoid polluting value.rs with a bunch of boilerplate?