### PR TITLE
value: implement From<Value> for Yaml

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -193,6 +193,22 @@ impl From<Yaml> for Value {
     }
 }
 
+impl From<Value> for Yaml {
+    fn from(yaml: Value) -> Self {
+        match yaml {
+            Value::F64(f) => Yaml::Real(format!("{}", f)),
+            Value::I64(i) => Yaml::Integer(i),
+            Value::String(s) => Yaml::String(s),
+            Value::Bool(s) => Yaml::Boolean(s),
+            Value::Sequence(seq) => Yaml::Array(seq.into_iter().map(Into::into).collect()),
+            Value::Mapping(map) => {
+                Yaml::Hash(map.into_iter().map(|(k, v)| (k.into(), v.into())).collect())
+            }
+            Value::Null => Yaml::Null,
+        }
+    }
+}
+
 impl Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer


### PR DESCRIPTION
This allows this crate's `Value` type to be used in libraries which
manipulate `rust-yaml`'s values directly (e.g., for supplemental
specification support).