### PR TITLE
Ensure that version numbers are in sync with crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_yaml"
-version = "0.7.1" # remember to update html_root_url
+version = "0.7.1"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "YAML support for Serde"
@@ -18,3 +18,4 @@ yaml-rust = { version = "0.3.5", features = ["preserve_order"] }
 [dev-dependencies]
 serde_derive = "1.0"
 unindent = "0.1"
+version-sync = "0.3"

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate version_sync;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This adds an integration test which will fail if the README and `lib.rs` files don't mention the correct crate version number.