### PR TITLE
Use yaml-rust 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["yaml", "serde"]
 linked-hash-map = "0.5"
 num-traits = "0.1.37"
 serde = "1.0"
-yaml-rust = { version = "0.3.5", features = ["preserve_order"] }
+yaml-rust = { git = "https://github.com/chyh1990/yaml-rust"}
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["yaml", "serde"]
 linked-hash-map = "0.5"
 num-traits = "0.1.37"
 serde = "1.0"
-yaml-rust = { git = "https://github.com/chyh1990/yaml-rust"}
+yaml-rust = "0.4"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,8 +32,8 @@ pub struct Loader {
 }
 
 impl MarkedEventReceiver for Loader {
-    fn on_event(&mut self, event: &YamlEvent, marker: Marker) {
-        let event = match *event {
+    fn on_event(&mut self, event: YamlEvent, marker: Marker) {
+        let event = match event {
             YamlEvent::Nothing | YamlEvent::StreamStart | YamlEvent::StreamEnd |
             YamlEvent::DocumentStart | YamlEvent::DocumentEnd => return,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! // Serialize it to a YAML string.
 //! let s = serde_yaml::to_string(&map).unwrap();
-//! assert_eq!(s, "---\nx: 1\ny: 2");
+//! assert_eq!(s, "---\nx: 1\n\"y\": 2");
 //!
 //! // Deserialize it back to a Rust type.
 //! let deserialized_map: BTreeMap<String, f64> = serde_yaml::from_str(&s).unwrap();
@@ -53,7 +53,7 @@
 //! let point = Point { x: 1.0, y: 2.0 };
 //!
 //! let s = serde_yaml::to_string(&point).unwrap();
-//! assert_eq!(s, "---\nx: 1\ny: 2");
+//! assert_eq!(s, "---\nx: 1\n\"y\": 2");
 //!
 //! let deserialized_point: Point = serde_yaml::from_str(&s).unwrap();
 //! assert_eq!(point, deserialized_point);

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -94,7 +94,7 @@ fn test_map() {
     let yaml = unindent(r#"
         ---
         x: 1
-        y: 2"#);
+        "y": 2"#);
     test_serde(&thing, &yaml);
 }
 
@@ -114,7 +114,7 @@ fn test_basic_struct() {
     let yaml = unindent(r#"
         ---
         x: -4
-        y: "hi\tquoted"
+        "y": "hi\tquoted"
         z: true"#);
     test_serde(&thing, &yaml);
 }
@@ -124,12 +124,10 @@ fn test_nested_vec() {
     let thing = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let yaml = unindent("
         ---
-        - 
-          - 1
+        - - 1
           - 2
           - 3
-        - 
-          - 4
+        - - 4
           - 5
           - 6");
     test_serde(&thing, &yaml);
@@ -148,7 +146,7 @@ fn test_nested_struct() {
     let thing = Outer { inner: Inner { v: 512 } };
     let yaml = unindent(r#"
         ---
-        inner: 
+        inner:
           v: 512"#);
     test_serde(&thing, &yaml);
 }
@@ -225,7 +223,7 @@ fn test_tuple_variant() {
     let thing = Variant::Rgb(32, 64, 96);
     let yaml = unindent(r#"
         ---
-        Rgb: 
+        Rgb:
           - 32
           - 64
           - 96"#);
@@ -245,7 +243,7 @@ fn test_struct_variant() {
     };
     let yaml = unindent(r#"
         ---
-        Color: 
+        Color:
           r: 32
           g: 64
           b: 96"#);
@@ -274,7 +272,7 @@ fn test_value() {
     let yaml = unindent(r#"
         ---
         type: primary
-        config: 
+        config:
           - ~
           - true
           - 65535
@@ -300,7 +298,7 @@ fn test_mapping() {
 
     let yaml = unindent("
         ---
-        substructure: 
+        substructure:
           a: foo
           b: bar");
 


### PR DESCRIPTION
As yaml-rust 0.4 got publisched on crates.io recently, it would be nice to use it for serde-yaml. There are some some fixes (especially for the emitter) I'd really like use with serde.