### PR TITLE
bump yaml-rust to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["yaml", "serde"]
 linked-hash-map = "0.5"
 num-traits = "0.1.37"
 serde = "1.0"
-yaml-rust = { version = "0.3.5", features = ["preserve_order"] }
+yaml-rust = "0.4"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,15 +32,15 @@ pub struct Loader {
 }
 
 impl MarkedEventReceiver for Loader {
-    fn on_event(&mut self, event: &YamlEvent, marker: Marker) {
-        let event = match *event {
+    fn on_event(&mut self, event: YamlEvent, marker: Marker) {
+        let event = match event {
             YamlEvent::Nothing | YamlEvent::StreamStart | YamlEvent::StreamEnd |
             YamlEvent::DocumentStart | YamlEvent::DocumentEnd => return,
 
             YamlEvent::Alias(id) => Event::Alias(id),
-            YamlEvent::Scalar(ref value, style, id, ref tag) => {
+            YamlEvent::Scalar(value, style, id, tag) => {
                 self.aliases.insert(id, self.events.len());
-                Event::Scalar(value.clone(), style, tag.clone())
+                Event::Scalar(value, style, tag)
             }
             YamlEvent::SequenceStart(id) => {
                 self.aliases.insert(id, self.events.len());

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -124,11 +124,11 @@ fn test_nested_vec() {
     let thing = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let yaml = unindent("
         ---
-        - 
+        -
           - 1
           - 2
           - 3
-        - 
+        -
           - 4
           - 5
           - 6");
@@ -148,7 +148,7 @@ fn test_nested_struct() {
     let thing = Outer { inner: Inner { v: 512 } };
     let yaml = unindent(r#"
         ---
-        inner: 
+        inner:
           v: 512"#);
     test_serde(&thing, &yaml);
 }
@@ -225,7 +225,7 @@ fn test_tuple_variant() {
     let thing = Variant::Rgb(32, 64, 96);
     let yaml = unindent(r#"
         ---
-        Rgb: 
+        Rgb:
           - 32
           - 64
           - 96"#);
@@ -245,7 +245,7 @@ fn test_struct_variant() {
     };
     let yaml = unindent(r#"
         ---
-        Color: 
+        Color:
           r: 32
           g: 64
           b: 96"#);
@@ -274,7 +274,7 @@ fn test_value() {
     let yaml = unindent(r#"
         ---
         type: primary
-        config: 
+        config:
           - ~
           - true
           - 65535
@@ -300,7 +300,7 @@ fn test_mapping() {
 
     let yaml = unindent("
         ---
-        substructure: 
+        substructure:
           a: foo
           b: bar");
 


### PR DESCRIPTION
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>

---

Some tests are still failing, so help is very welcomed (probably those are bugs in yaml-rust)..

```rust
---- test_basic_struct stdout ----
	thread 'test_basic_struct' panicked at 'assertion failed: `(left == right)`
  left: `"---\nx: -4\ny: \"hi\\tquoted\"\nz: true"`,
 right: `"---\nx: -4\n\"y\": \"hi\\tquoted\"\nz: true"`', tests/test_serde.rs:27:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- test_map stdout ----
	thread 'test_map' panicked at 'assertion failed: `(left == right)`
  left: `"---\nx: 1\ny: 2"`,
 right: `"---\nx: 1\n\"y\": 2"`', tests/test_serde.rs:27:4

---- test_nested_vec stdout ----
	thread 'test_nested_vec' panicked at 'assertion failed: `(left == right)`
  left: `"---\n-\n  - 1\n  - 2\n  - 3\n-\n  - 4\n  - 5\n  - 6"`,
 right: `"---\n- - 1\n  - 2\n  - 3\n- - 4\n  - 5\n  - 6"`', tests/test_serde.rs:27:4
```