### PR TITLE
Add Default implementation for Value

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -40,6 +40,47 @@ pub enum Value {
     Mapping(Mapping),
 }
 
+/// The default value is `Value::Null`.
+///
+/// This is useful for handling omitted `Value` fields when deserializing.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// #
+/// # extern crate serde_yaml;
+/// #
+/// use serde_yaml::Value;
+///
+/// #[derive(Deserialize)]
+/// struct Settings {
+///     level: i32,
+///     #[serde(default)]
+///     extras: Value,
+/// }
+///
+/// # fn try_main() -> Result<(), serde_yaml::Error> {
+/// let data = r#" { "level": 42 } "#;
+/// let s: Settings = serde_yaml::from_str(data)?;
+///
+/// assert_eq!(s.level, 42);
+/// assert_eq!(s.extras, Value::Null);
+/// #
+/// #     Ok(())
+/// # }
+/// #
+/// # fn main() {
+/// #     try_main().unwrap()
+/// # }
+/// ```
+impl Default for Value {
+    fn default() -> Value {
+        Value::Null
+    }
+}
+
 /// A YAML sequence in which the elements are `serde_yaml::Value`.
 pub type Sequence = Vec<Value>;
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -50,6 +50,11 @@ where
 }
 
 #[test]
+fn test_default() {
+    assert_eq!(Value::default(), Value::Null);
+}
+
+#[test]
 fn test_int() {
     let thing = 256;
     let yaml = unindent(


### PR DESCRIPTION
Fixes #119 

This PR defines a default value for `serde_yaml::Value` struct.