### PR TITLE
Add seeded versions of deserialize functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,11 @@ pub use self::mapping::Mapping;
 pub use self::ser::{to_string, to_vec, to_writer};
 pub use self::value::{from_value, to_value, Index, Number, Sequence, Value};
 
+/// Deserialization with seeds
+pub mod seed {
+    pub use super::de::{from_reader_seed, from_slice_seed, from_str_seed};
+}
+
 mod de;
 mod error;
 mod mapping;


### PR DESCRIPTION
Allows usage of `DeserializeSeed` types.

The `T` parameters on `_seed` functions are required because it's not possible to extract `S::Value` out of the higher-rank bound without also specifying that for all `'de`, `S::Value` is indeed the same type.