### PR TITLE
Value == u64

### DIFF
--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -130,6 +130,6 @@ macro_rules! partialeq_numeric {
 
 partialeq_numeric! {
     [i8 i16 i32 i64 isize], as_i64, i64
-    [u8 u16 u32 usize], as_i64, i64
+    [u8 u16 u32 u64 usize], as_u64, u64
     [f32 f64], as_f64, f64
 }


### PR DESCRIPTION
The comparison of unsigned integers as `i64` was last touched in #62 (Apr 21, 2017) and `as_u64` as added in #64 (Apr 25, 2017), explaining why the unsigned integers didn't compare as `u64` in the first place.