### PR TITLE
Make ErrorImpl public and expose it within Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use yaml_rust::scanner::{self, Marker, ScanError};
 
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing YAML data.
-pub struct Error(Box<ErrorImpl>);
+pub struct Error(pub Box<ErrorImpl>);
 
 /// Alias for a `Result` with the error type `serde_yaml::Error`.
 pub type Result<T> = result::Result<T, Error>;
@@ -20,16 +20,31 @@ pub type Result<T> = result::Result<T, Error>;
 /// deserializing a value using YAML.
 #[derive(Debug)]
 pub enum ErrorImpl {
+    /// Custom error
     Message(String, Option<Pos>),
 
+    /// Emit error
     Emit(emitter::EmitError),
+
+    /// Scan error
     Scan(scanner::ScanError),
+
+    /// `io::Error`
     Io(io::Error),
+
+    /// `str::Utf8Error`
     Utf8(str::Utf8Error),
+
+    /// `string::FromUtf8Error`
     FromUtf8(string::FromUtf8Error),
 
+    /// EOF while parsing a value
     EndOfStream,
+
+    /// Multiple documents (not supported)
     MoreThanOneDocument,
+
+    /// Recursion limit exceeded
     RecursionLimitExceeded,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 ))]
 
 pub use crate::de::{from_reader, from_slice, from_str};
-pub use crate::error::{Error, Location, Result};
+pub use crate::error::{Error, ErrorImpl, Location, Result};
 pub use crate::mapping::Mapping;
 pub use crate::ser::{to_string, to_vec, to_writer};
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};


### PR DESCRIPTION
This change allows differentiating between various types of errors without resorting to checking the string representation.

Unfortunately, it is not possible to check directly in a `match` on a `Result` since the `Box` does not automatically dereference in that situation. You have to do something like:

~~~ rust
match serde_yaml::from_str(&text) {
    Ok(v) => {
        // Handle success
    }
    Err(e) => {
        if let serde_yaml::ErrorImpl::EndOfStream = *(e.0) {
            // Handle EndOfStream error
        } else {
            // Handle all other errors
        }
    }
}
~~~

_I disclaim ownership of these changes. They are owned by whoever owns the bulk of the rest of the code. (I am not a lawyer, but I’ll head them off at the pass if I can.)_