### PR TITLE
Run clippy on latest nightly that has clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: rust
 
-matrix:
-  include:
-    - rust: stable
-    - rust: beta
-    - rust: nightly
-    - rust: 1.31.0
-    - rust: nightly
-      env: CLIPPY
-      script: |
-          if rustup component add clippy; then
-              cargo clippy
-          fi
+rust:
+  - stable
+  - beta
+  - nightly
+  - 1.31.0
 
 script:
   - cargo build
   - cargo test
+
+matrix:
+  include:
+    - name: Clippy
+      install:
+        - CLIPPY_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy)
+        - echo "Latest nightly with Clippy is $CLIPPY_NIGHTLY"
+        - rustup set profile minimal
+        - rustup default "$CLIPPY_NIGHTLY"
+        - rustup component add clippy
+      script:
+        - cargo clippy


### PR DESCRIPTION
Previously, it would run on the most recent nightly always, and simply skip Clippy if it wasn't available in that nightly.