### PR TITLE
make mapping module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub mod seed {
 
 mod de;
 mod error;
-mod mapping;
+pub mod mapping;
 mod number;
 mod path;
 mod ser;


### PR DESCRIPTION
For [consistency](https://github.com/serde-rs/json/blob/master/src/lib.rs#L433) with serde-json the mapping module should be public. With it private, mapping::Iter is an [unnameable type](https://github.com/petrochenkov/rfcs/blob/9901089b2467b0813456479ba03642e9f0ac0912/text/0000-type-privacy.md#lint-3-voldemort-types-its-reachable-but-i-cant-name-it).