### PR TITLE
YAML only has two NaNs

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -323,8 +323,9 @@ impl PartialEq for N {
             (N::NegInt(a), N::NegInt(b)) => a == b,
             (N::Float(a), N::Float(b)) => {
                 if a.is_nan() && b.is_nan() {
-                    // Compare NaN for bitwise equality.
-                    a.to_bits() == b.to_bits()
+                    // YAML only has two NaNs;
+                    // the bit representation isn't preserved
+                    a.is_sign_positive() == b.is_sign_positive()
                 } else {
                     a == b
                 }

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -1,0 +1,15 @@
+use serde_yaml::{Number, Value};
+
+#[test]
+fn test_nan() {
+    let pos_nan = serde_yaml::from_str::<Value>("NaN").unwrap();
+    let neg_nan = serde_yaml::from_str::<Value>("-NaN").unwrap();
+    assert_eq!(pos_nan, pos_nan);
+    assert_eq!(neg_nan, neg_nan);
+    assert_ne!(pos_nan, neg_nan);
+
+    let significand_mask = 0xF_FFFF_FFFF_FFFF;
+    let bits = (f64::NAN.to_bits() ^ significand_mask) | 1;
+    let different_pos_nan = Value::Number(Number::from(f64::from_bits(bits)));
+    assert_eq!(pos_nan, different_pos_nan);
+}

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -1,4 +1,5 @@
 use serde_yaml::{Number, Value};
+use std::f64;
 
 #[test]
 fn test_nan() {


### PR DESCRIPTION
There is only `.nan` and `-.nan`. Update the PartialEq impl for Value to align with this; for example we shouldn't allow building a YAML map with multiple `.nan` keys having different bit representations.