### PR TITLE
Only accept finite values from f64::from_str

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -582,8 +582,10 @@ where
     if v == ".nan" || v == ".NaN" || v == ".NAN" {
         return visitor.visit_f64(f64::NAN);
     }
-    if let Ok(n) = v.parse() {
-        return visitor.visit_f64(n);
+    if let Ok(n) = v.parse::<f64>() {
+        if n.is_finite() {
+            return visitor.visit_f64(n);
+        }
     }
     visitor.visit_str(v)
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -202,9 +202,9 @@ impl Number {
     /// ```
     /// # use std::f64;
     /// # fn yaml(i: &str) -> serde_yaml::Value { serde_yaml::from_str(i).unwrap() }
-    /// assert_eq!(yaml("inf").as_f64(), Some(f64::INFINITY));
-    /// assert_eq!(yaml("-inf").as_f64(), Some(f64::NEG_INFINITY));
-    /// assert!(yaml("NaN").as_f64().unwrap().is_nan());
+    /// assert_eq!(yaml(".inf").as_f64(), Some(f64::INFINITY));
+    /// assert_eq!(yaml("-.inf").as_f64(), Some(f64::NEG_INFINITY));
+    /// assert!(yaml(".nan").as_f64().unwrap().is_nan());
     /// ```
     #[inline]
     pub fn as_f64(&self) -> Option<f64> {
@@ -323,9 +323,9 @@ impl PartialEq for N {
             (N::NegInt(a), N::NegInt(b)) => a == b,
             (N::Float(a), N::Float(b)) => {
                 if a.is_nan() && b.is_nan() {
-                    // YAML only has two NaNs;
+                    // YAML only has one NaN;
                     // the bit representation isn't preserved
-                    a.is_sign_positive() == b.is_sign_positive()
+                    true
                 } else {
                     a == b
                 }

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -3,11 +3,12 @@ use std::f64;
 
 #[test]
 fn test_nan() {
-    let pos_nan = serde_yaml::from_str::<Value>("NaN").unwrap();
-    let neg_nan = serde_yaml::from_str::<Value>("-NaN").unwrap();
+    let pos_nan = serde_yaml::from_str::<Value>(".nan").unwrap();
+    assert!(pos_nan.is_f64());
     assert_eq!(pos_nan, pos_nan);
-    assert_eq!(neg_nan, neg_nan);
-    assert_ne!(pos_nan, neg_nan);
+
+    let neg_fake_nan = serde_yaml::from_str::<Value>("-.nan").unwrap();
+    assert!(neg_fake_nan.is_string());
 
     let significand_mask = 0xF_FFFF_FFFF_FFFF;
     let bits = (f64::NAN.to_bits() ^ significand_mask) | 1;


### PR DESCRIPTION
Upon closer inspection of #156, we were incorrectly producing negative nans (and also infinities) through f64::from_str which were not supposed to be YAML nans or infinities.