### PR TITLE
bump linked hashmap to min 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["yaml", "serde"]
 
 [dependencies]
 dtoa = "0.4"
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 serde = "1.0.60"
 yaml-rust = "0.4"
 


### PR DESCRIPTION
linked_hashmap has an unsound behaviour which was fixed 0.5.3. Bumping the dependency so that dependents do not pull the lower unsound versions based on resolution. 

[Advisory](https://github.com/RustSec/advisory-db/issues/298)

Side note: yaml_rust is affected as well ([pr] https://github.com/chyh1990/yaml-rust/pull/162) so that dependency will have to be updated when they release as well. 