### PR TITLE
Add methods to support multidoc deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
     clippy::match_like_matches_macro,
 )]
 
-pub use crate::de::{from_reader, from_slice, from_str};
+pub use crate::de::{from_reader, from_slice, from_str, from_str_multidoc};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{to_string, to_vec, to_writer};
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};
@@ -112,7 +112,7 @@ pub use crate::mapping::Mapping;
 /// Deserializer type. Data formats that have a public Deserializer should not
 /// copy these signatures.
 pub mod seed {
-    pub use super::de::{from_reader_seed, from_slice_seed, from_str_seed};
+    pub use super::de::{from_reader_seed, from_slice_seed, from_str_seed, from_str_seed_multidoc};
 }
 
 mod de;

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -72,6 +72,26 @@ fn test_option() {
 }
 
 #[test]
+fn test_multidoc() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Data {
+        a: bool,
+    }
+    let yaml = unindent(
+        "
+        ---
+        a: true
+        ...
+        ---
+        a: false
+        ...",
+    );
+    let expected = vec![Data { a: true }, Data { a: false }];
+    let deserialized: Vec<Data> = serde_yaml::from_str_multidoc(&yaml).unwrap();
+    assert_eq!(&expected, &deserialized);
+}
+
+#[test]
 fn test_option_alias() {
     #[derive(Deserialize, PartialEq, Debug)]
     struct Data {


### PR DESCRIPTION
Simply reorganizes creation of deserializer, and adds methods which correctly use the remaining state in multi-document inputs to deserialize these into Vecs.

Resolves https://github.com/dtolnay/serde-yaml/issues/175