### PR TITLE
Add a check for strings disguised as leading zeros followed by numbers

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -560,7 +560,7 @@ where
     // if we are left with leading zero(s) followed by numeric characters
     // this is in fact a string according to the YAML 1.2 spec
     // https://yaml.org/spec/1.2/spec.html#id2761292
-    if v.len() > 1 &&  v.starts_with("0") && v.chars().all(char::is_numeric) {
+    if v.len() > 1 &&  v.starts_with('0') && v.chars().all(char::is_numeric) {
         return visitor.visit_str(v);
     }
     if let Ok(n) = v.parse() {

--- a/src/de.rs
+++ b/src/de.rs
@@ -556,6 +556,13 @@ where
             return visitor.visit_i64(n);
         }
     }
+    // After handling the different number encodings above
+    // if we are left with leading zero(s) followed by numeric characters
+    // this is in fact a string according to the YAML 1.2 spec
+    // https://yaml.org/spec/1.2/spec.html#id2761292
+    if v.len() > 1 &&  v.starts_with("0") && v.chars().all(char::is_numeric) {
+        return visitor.visit_str(v);
+    }
     if let Ok(n) = v.parse() {
         return visitor.visit_u64(n);
     }

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -10,6 +10,9 @@ fn test_nan() {
     let neg_fake_nan = serde_yaml::from_str::<Value>("-.nan").unwrap();
     assert!(neg_fake_nan.is_string());
 
+    let num_string = serde_yaml::from_str::<Value>("01").unwrap();
+    assert!(num_string.is_string());
+
     let significand_mask = 0xF_FFFF_FFFF_FFFF;
     let bits = (f64::NAN.to_bits() ^ significand_mask) | 1;
     let different_pos_nan = Value::Number(Number::from(f64::from_bits(bits)));


### PR DESCRIPTION
Closes #179.

According to the YAML 1.2 spec (https://yaml.org/spec/1.2/spec.html#id2761292) numbers sequences with a leading zeros (that are not special encoding identifiers such as 0x, 0b, etc) are actually strings.

This patch handles this case, all existing tests still pass.