### PR TITLE
Add IntoDeserializer implementation to Value enum

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,6 +1,6 @@
 use crate::ser::SerializerToYaml;
 use crate::{Error, Mapping};
-use serde::de::{Deserialize, DeserializeOwned};
+use serde::de::{Deserialize, DeserializeOwned, IntoDeserializer};
 use serde::Serialize;
 use std::f64;
 use std::hash::{Hash, Hasher};
@@ -630,6 +630,14 @@ impl Hash for Value {
             Value::Sequence(seq) => (4, seq).hash(state),
             Value::Mapping(map) => (5, map).hash(state),
         }
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
     }
 }
 

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::eq_op)]
 
+use serde::de::IntoDeserializer;
+use serde::Deserialize;
+use serde_derive::Deserialize;
 use serde_yaml::{Number, Value};
 use std::f64;
 
@@ -22,4 +25,31 @@ fn test_nan() {
 fn test_digits() {
     let num_string = serde_yaml::from_str::<Value>("01").unwrap();
     assert!(num_string.is_string());
+}
+
+#[test]
+fn test_into_deserializer() {
+    let value = serde_yaml::from_str::<Value>("xyz").unwrap();
+    let s = String::deserialize(value.into_deserializer()).unwrap();
+    assert_eq!(s, "xyz");
+
+    let value = serde_yaml::from_str::<Value>("- first\n- second\n- third").unwrap();
+    let arr = Vec::<String>::deserialize(value.into_deserializer()).unwrap();
+    assert_eq!(arr, &["first", "second", "third"]);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Test {
+        first: String,
+        second: u32,
+    }
+
+    let value = serde_yaml::from_str::<Value>("first: abc\nsecond: 99").unwrap();
+    let test = Test::deserialize(value.into_deserializer()).unwrap();
+    assert_eq!(
+        test,
+        Test {
+            first: "abc".to_string(),
+            second: 99
+        }
+    )
 }

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -29,6 +29,12 @@ fn test_digits() {
 
 #[test]
 fn test_into_deserializer() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Test {
+        first: String,
+        second: u32,
+    }
+
     let value = serde_yaml::from_str::<Value>("xyz").unwrap();
     let s = String::deserialize(value.into_deserializer()).unwrap();
     assert_eq!(s, "xyz");
@@ -36,12 +42,6 @@ fn test_into_deserializer() {
     let value = serde_yaml::from_str::<Value>("- first\n- second\n- third").unwrap();
     let arr = Vec::<String>::deserialize(value.into_deserializer()).unwrap();
     assert_eq!(arr, &["first", "second", "third"]);
-
-    #[derive(Debug, Deserialize, PartialEq)]
-    struct Test {
-        first: String,
-        second: u32,
-    }
 
     let value = serde_yaml::from_str::<Value>("first: abc\nsecond: 99").unwrap();
     let test = Test::deserialize(value.into_deserializer()).unwrap();


### PR DESCRIPTION
I've taken the liberty of implementing `IntoDeserializer` for Value as mentioned in https://github.com/dtolnay/serde-yaml/issues/169.

I could use this functionality in my crates.