### PR TITLE
Impl Mapping::entry_or_insert

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -78,7 +78,15 @@ impl Mapping {
     pub fn remove(&mut self, k: &Value) -> Option<Value> {
         self.map.remove(k)
     }
-
+    
+    /// Ensures a key's corresponding value is in the entry by inserting 
+    /// the default if empty.
+    /// Returns a mutable reference to the value in the entry.
+    #[inline]
+    pub fn entry_or_insert(&mut self, k: Value, default: Value) -> &mut Value {
+        self.map.entry(k).or_insert(default)
+    }
+    
     /// Returns the maximum number of key-value pairs the map can hold without
     /// reallocating.
     #[inline]

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -52,12 +52,7 @@ impl Index for usize {
             }
             Value::Mapping(map) => {
                 let n = Value::Number((*self).into());
-                // TODO: use entry() once LinkedHashMap supports entry()
-                // https://github.com/contain-rs/linked-hash-map/issues/5
-                if !map.contains_key(&n) {
-                    map.insert(n.clone(), Value::Null);
-                }
-                map.get_mut(&n).unwrap()
+                map.entry_or_insert(n, Value::Null)
             }
             _ => panic!("cannot access index {} of YAML {}", self, Type(v)),
         }
@@ -85,12 +80,7 @@ impl Index for Value {
         }
         match v {
             Value::Mapping(map) => {
-                // TODO: use entry() once LinkedHashMap supports entry()
-                // https://github.com/contain-rs/linked-hash-map/issues/5
-                if !map.contains_key(self) {
-                    map.insert(self.clone(), Value::Null);
-                }
-                map.get_mut(self).unwrap()
+                map.entry_or_insert(self.clone(), Value::Null)
             }
             _ => panic!("cannot access key {:?} in YAML {}", self, Type(v)),
         }


### PR DESCRIPTION
According to the actual use case of `serde_yaml`, impl `fn entry_or_insert()` for `Mapping`. 

```rust
    /// Ensures a key's corresponding value is in the entry by inserting 
    /// the default if empty.
    /// Returns a mutable reference to the value in the entry.
    #[inline]
    pub fn entry_or_insert(&mut self, k: Value, default: Value) -> &mut Value {
        self.map.entry(k).or_insert(default)
    }
 ```

Relate https://github.com/dtolnay/serde-yaml/issues/58 . We don’t need to implement our own `entry()` API, but only need to combine the existing interfaces.

Also, I released my new  crate [`ritelinked`](https://github.com/ritedb/ritelinked), which supports `LinkedHashMap` and `LinkedHashSet`, provides better performance in some cases and is under active maintenance, would you consider using it to replace `linked-hash-map` ? 