### PR TITLE
Fix FmtToIoWriter::write_str to call write_all

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -867,7 +867,7 @@ where
     W: io::Write,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        if self.writer.write(s.as_bytes()).is_err() {
+        if self.writer.write_all(s.as_bytes()).is_err() {
             return Err(fmt::Error);
         }
         Ok(())


### PR DESCRIPTION
I experienced bytes being silently dropped when serializing large objects to compressed files using `serde_yaml` and `flate2`/`bzip2`. I believe this PR will fix the issue, but I haven't tested it yet to confirm. Regardless, it's clear that this change is necessary so that `FmtToIoWriter` meets the contract of `std::fmt::Write`.

Previously, the implementation could silently fail to write some bytes. Now, the implementation should either write all the bytes or return an error.

The docs for [`std::fmt::Write::write_str`](https://doc.rust-lang.org/std/fmt/trait.Write.html#tymethod.write_str) say, "This method can only succeed if the entire string slice was successfully written, and this method will not return until all data has been written or an error occurs." So, `FmtToIoWriter::write_str` must call [`std::io::Write::write_all`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all) instead of [`std::io::Write::write`](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write) on the inner writer in order to ensure that all the bytes are written.