### PR TITLE
Handwrite a better PartialOrd for Number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
     clippy::should_implement_trait,
     // things are often more readable this way
     clippy::cast_lossless,
+    clippy::match_same_arms,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
     clippy::option_if_let_else,


### PR DESCRIPTION
The derived implementation previously had at least 2 problems:

- It was incompatible with the handwritten PartialEq impl. This definitely warrants a fix. It was possible in the case of NaNs for PartialEq to consider then equal while PartialOrd would consider them incomparable. This violates the following documented requirement of the PartialOrd trait in relation to PartialEq: *"`a == b` if and only if `partial_cmp(a, b) == Some(Equal)`"*.

- Positive integers would sort less than negative integers, which can be unexpected. It's unclear whether this matters to any real use case but we might as well fix it since it's easy.