### PR TITLE
Replace LinkedHashMap with IndexMap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
       - run: cargo test
 
   msrv:
-    name: Rust 1.31.0
+    name: Rust 1.38.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.31.0
+      - uses: dtolnay/rust-toolchain@1.38.0
       - run: cargo check
 
   clippy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["yaml", "serde"]
 
 [dependencies]
 dtoa = "0.4"
-linked-hash-map = "0.5.3"
+indexmap = "1.5"
 serde = "1.0.69"
 yaml-rust = "0.4.5"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
     clippy::option_if_let_else,
+    clippy::redundant_else,
     clippy::single_match_else,
     // code is acceptable
     clippy::cast_possible_wrap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
     clippy::should_implement_trait,
     // things are often more readable this way
     clippy::cast_lossless,
+    clippy::if_not_else,
     clippy::match_same_arms,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
     // code is acceptable
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
+    clippy::items_after_statements,
     // noisy
     clippy::missing_errors_doc,
     clippy::must_use_candidate,

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -3,7 +3,9 @@
 use crate::Value;
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
@@ -120,6 +122,20 @@ impl Mapping {
         IterMut {
             iter: self.map.iter_mut(),
         }
+    }
+}
+
+impl Hash for Mapping {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash the kv pairs in a way that is not sensitive to their order.
+        let mut xor = 0;
+        for (k, v) in self {
+            let mut hasher = DefaultHasher::new();
+            k.hash(&mut hasher);
+            v.hash(&mut hasher);
+            xor ^= hasher.finish();
+        }
+        xor.hash(state);
     }
 }
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -8,7 +8,7 @@ use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
 /// A YAML mapping in which the keys and values are both `serde_yaml::Value`.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Mapping {
     map: IndexMap<Value, Value>,
 }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -1,7 +1,7 @@
 //! A YAML mapping and its iterator types.
 
 use crate::Value;
-use linked_hash_map::LinkedHashMap;
+use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::iter::FromIterator;
@@ -10,7 +10,7 @@ use std::ops::{Index, IndexMut};
 /// A YAML mapping in which the keys and values are both `serde_yaml::Value`.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd)]
 pub struct Mapping {
-    map: LinkedHashMap<Value, Value>,
+    map: IndexMap<Value, Value>,
 }
 
 impl Mapping {
@@ -24,7 +24,7 @@ impl Mapping {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Mapping {
-            map: LinkedHashMap::with_capacity(capacity),
+            map: IndexMap::with_capacity(capacity),
         }
     }
 
@@ -149,7 +149,7 @@ impl FromIterator<(Value, Value)> for Mapping {
     #[inline]
     fn from_iter<I: IntoIterator<Item = (Value, Value)>>(iter: I) -> Self {
         Mapping {
-            map: LinkedHashMap::from_iter(iter),
+            map: IndexMap::from_iter(iter),
         }
     }
 }
@@ -179,7 +179,7 @@ macro_rules! delegate_iterator {
 
 /// Iterator over `&serde_yaml::Mapping`.
 pub struct Iter<'a> {
-    iter: linked_hash_map::Iter<'a, Value, Value>,
+    iter: indexmap::map::Iter<'a, Value, Value>,
 }
 
 delegate_iterator!((Iter<'a>) => (&'a Value, &'a Value));
@@ -197,7 +197,7 @@ impl<'a> IntoIterator for &'a Mapping {
 
 /// Iterator over `&mut serde_yaml::Mapping`.
 pub struct IterMut<'a> {
-    iter: linked_hash_map::IterMut<'a, Value, Value>,
+    iter: indexmap::map::IterMut<'a, Value, Value>,
 }
 
 delegate_iterator!((IterMut<'a>) => (&'a Value, &'a mut Value));
@@ -215,7 +215,7 @@ impl<'a> IntoIterator for &'a mut Mapping {
 
 /// Iterator over `serde_yaml::Mapping` by value.
 pub struct IntoIter {
-    iter: linked_hash_map::IntoIter<Value, Value>,
+    iter: indexmap::map::IntoIter<Value, Value>,
 }
 
 delegate_iterator!((IntoIter) => (Value, Value));

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -3,6 +3,7 @@
 use crate::Value;
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -136,6 +137,85 @@ impl Hash for Mapping {
             xor ^= hasher.finish();
         }
         xor.hash(state);
+    }
+}
+
+impl PartialOrd for Mapping {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let mut self_entries = Vec::from_iter(self);
+        let mut other_entries = Vec::from_iter(other);
+
+        // Sort in an arbitrary order that is consistent with Value's PartialOrd
+        // impl.
+        fn total_cmp(a: &Value, b: &Value) -> Ordering {
+            match (a, b) {
+                (Value::Null, Value::Null) => Ordering::Equal,
+                (Value::Null, _) => Ordering::Less,
+                (_, Value::Null) => Ordering::Greater,
+
+                (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
+                (Value::Bool(_), _) => Ordering::Less,
+                (_, Value::Bool(_)) => Ordering::Greater,
+
+                (Value::Number(a), Value::Number(b)) => a.total_cmp(b),
+                (Value::Number(_), _) => Ordering::Less,
+                (_, Value::Number(_)) => Ordering::Greater,
+
+                (Value::String(a), Value::String(b)) => a.cmp(b),
+                (Value::String(_), _) => Ordering::Less,
+                (_, Value::String(_)) => Ordering::Greater,
+
+                (Value::Sequence(a), Value::Sequence(b)) => iter_cmp_by(a, b, total_cmp),
+                (Value::Sequence(_), _) => Ordering::Less,
+                (_, Value::Sequence(_)) => Ordering::Greater,
+
+                (Value::Mapping(a), Value::Mapping(b)) => {
+                    iter_cmp_by(a, b, |(ak, av), (bk, bv)| {
+                        total_cmp(ak, bk).then_with(|| total_cmp(av, bv))
+                    })
+                }
+            }
+        }
+
+        fn iter_cmp_by<I, F>(this: I, other: I, mut cmp: F) -> Ordering
+        where
+            I: IntoIterator,
+            F: FnMut(I::Item, I::Item) -> Ordering,
+        {
+            let mut this = this.into_iter();
+            let mut other = other.into_iter();
+
+            loop {
+                let x = match this.next() {
+                    None => {
+                        if other.next().is_none() {
+                            return Ordering::Equal;
+                        } else {
+                            return Ordering::Less;
+                        }
+                    }
+                    Some(val) => val,
+                };
+
+                let y = match other.next() {
+                    None => return Ordering::Greater,
+                    Some(val) => val,
+                };
+
+                match cmp(x, y) {
+                    Ordering::Equal => {}
+                    non_eq => return non_eq,
+                }
+            }
+        }
+
+        // While sorting by map key, we get to assume that no two keys are
+        // equal, otherwise they wouldn't both be in the map. This is not a safe
+        // assumption outside of this situation.
+        let total_cmp = |&(a, _): &_, &(b, _): &_| total_cmp(a, b);
+        self_entries.sort_by(total_cmp);
+        other_entries.sort_by(total_cmp);
+        self_entries.partial_cmp(&other_entries)
     }
 }
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -126,6 +126,7 @@ impl Mapping {
     }
 }
 
+#[allow(clippy::derive_hash_xor_eq)]
 impl Hash for Mapping {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Hash the kv pairs in a way that is not sensitive to their order.


### PR DESCRIPTION
IndexMap has equivalent guarantees as far as would be relevant to the serde_yaml API, and is actively maintained unlike LinkedHashMap.

The same switch in serde_json: https://github.com/serde-rs/json/pull/451.