### PR TITLE
Fixes tags being ignored for quoted scalars

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -687,9 +687,7 @@ fn visit_scalar<'de, V>(
 where
     V: Visitor<'de>,
 {
-    if style != TScalarStyle::Plain {
-        visitor.visit_str(v)
-    } else if let Some(TokenType::Tag(handle, suffix)) = tag {
+    if let Some(TokenType::Tag(handle, suffix)) = tag {
         if handle == "!!" {
             match suffix.as_ref() {
                 "bool" => match v.parse::<bool>() {
@@ -713,8 +711,10 @@ where
         } else {
             visitor.visit_str(v)
         }
-    } else {
+    } else if style == TScalarStyle::Plain {
         visit_untagged_str(visitor, v)
+    } else {
+        visitor.visit_str(v)
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/chyh1990/yaml-rust/issues/140. It looks like the parsing logic here is related to the code linked to in that issue, but does not actually use said code. So, opening up a PR here to fix the issue.

Succinctly, the issue is that this parses as a string, when it should parse as an int:

    foo: !!int "123"