### PR TITLE
Add ability to deserialize i128/u128 into Value::String

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -35,11 +35,29 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::Number(i.into()))
             }
 
+            serde_if_integer128! {
+                fn visit_i128<E>(self, v: i128) -> Result<Value, E>
+                where
+                    E: SError,
+                {
+                    Ok(Value::String(v.to_string()))
+                }
+            }
+
             fn visit_u64<E>(self, u: u64) -> Result<Value, E>
             where
                 E: SError,
             {
                 Ok(Value::Number(u.into()))
+            }
+
+            serde_if_integer128! {
+                fn visit_u128<E>(self, v: u128) -> Result<Value, E>
+                where
+                    E: SError,
+                {
+                    Ok(Value::String(v.to_string()))
+                }
             }
 
             fn visit_f64<E>(self, f: f64) -> Result<Value, E>

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::eq_op)]
 
+use indoc::indoc;
 use serde::de::IntoDeserializer;
 use serde::Deserialize;
 use serde_derive::Deserialize;
@@ -52,4 +53,26 @@ fn test_into_deserializer() {
             second: 99
         }
     );
+}
+
+#[test]
+fn test_i128_as_value() {
+    let expected = Value::String("-9223372036854775809".to_owned());
+    let yaml = indoc! {"
+            ---
+            -9223372036854775809
+        "};
+
+    assert_eq!(expected, serde_yaml::from_str::<Value>(yaml).unwrap());
+}
+
+#[test]
+fn test_u128_as_value() {
+    let expected = Value::String("18446744073709551616".to_owned());
+    let yaml = indoc! {"
+            ---
+            18446744073709551616
+        "};
+
+    assert_eq!(expected, serde_yaml::from_str::<Value>(yaml).unwrap());
 }


### PR DESCRIPTION
Yamls contained i128 and u128 can't be parsed in serde_yaml::Value

```
extern crate serde_yaml; // 0.8.17

fn main() {
    let i_value_result = serde_yaml::from_str::<serde_yaml::Value>("-9223372036854775809");
    let u_value_result = serde_yaml::from_str::<serde_yaml::Value>("18446744073709551616");

    println!("i128 {:?}", i_value_result);
    println!("u128 {:?}", u_value_result);
}
```
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=99eed228e67d069a74ca5a56be124628

Added implementation of visit_i128 and visit_u128 with string representation.