### PR TITLE
Make 128 bit support unconditional

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -4,7 +4,6 @@ use serde::de::{
     self, Deserialize, DeserializeOwned, DeserializeSeed, Expected, IgnoredAny as Ignore,
     IntoDeserializer, Unexpected, Visitor,
 };
-use serde::serde_if_integer128;
 use std::collections::BTreeMap;
 use std::f64;
 use std::fmt;
@@ -261,13 +260,11 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         self.de(|state| state.deserialize_i64(visitor))
     }
 
-    serde_if_integer128! {
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: Visitor<'de>,
-        {
-            self.de(|state| state.deserialize_i128(visitor))
-        }
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.de(|state| state.deserialize_i128(visitor))
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -298,13 +295,11 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         self.de(|state| state.deserialize_u64(visitor))
     }
 
-    serde_if_integer128! {
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: Visitor<'de>,
-        {
-            self.de(|state| state.deserialize_u128(visitor))
-        }
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.de(|state| state.deserialize_u128(visitor))
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -1002,18 +997,14 @@ where
     if let Ok(n) = v.parse() {
         return visitor.visit_u64(n);
     }
-    serde_if_integer128! {
-        if let Ok(n) = v.parse() {
-            return visitor.visit_u128(n);
-        }
+    if let Ok(n) = v.parse() {
+        return visitor.visit_u128(n);
     }
     if let Ok(n) = v.parse() {
         return visitor.visit_i64(n);
     }
-    serde_if_integer128! {
-        if let Ok(n) = v.parse() {
-            return visitor.visit_i128(n);
-        }
+    if let Ok(n) = v.parse() {
+        return visitor.visit_i128(n);
     }
     match trim_start_matches(v, '+') {
         ".inf" | ".Inf" | ".INF" => return visitor.visit_f64(f64::INFINITY),
@@ -1143,13 +1134,11 @@ impl<'de, 'a, 'r> de::Deserializer<'de> for &'r mut DeserializerFromEvents<'a> {
         self.deserialize_scalar(visitor)
     }
 
-    serde_if_integer128! {
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_scalar(visitor)
-        }
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_scalar(visitor)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -1180,13 +1169,11 @@ impl<'de, 'a, 'r> de::Deserializer<'de> for &'r mut DeserializerFromEvents<'a> {
         self.deserialize_scalar(visitor)
     }
 
-    serde_if_integer128! {
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_scalar(visitor)
-        }
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_scalar(visitor)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,7 +3,7 @@
 //! This module provides YAML serialization with the type `Serializer`.
 
 use crate::{error, Error, Result};
-use serde::{ser, serde_if_integer128};
+use serde::ser;
 use std::{fmt, io, num, str};
 use yaml_rust::{yaml, Yaml, YamlEmitter};
 
@@ -109,11 +109,9 @@ where
         self.write(doc)
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, v: i128) -> Result<()> {
-            let doc = SerializerToYaml.serialize_i128(v)?;
-            self.write(doc)
-        }
+    fn serialize_i128(self, v: i128) -> Result<()> {
+        let doc = SerializerToYaml.serialize_i128(v)?;
+        self.write(doc)
     }
 
     fn serialize_u8(self, v: u8) -> Result<()> {
@@ -136,11 +134,9 @@ where
         self.write(doc)
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, v: u128) -> Result<()> {
-            let doc = SerializerToYaml.serialize_u128(v)?;
-            self.write(doc)
-        }
+    fn serialize_u128(self, v: u128) -> Result<()> {
+        let doc = SerializerToYaml.serialize_u128(v)?;
+        self.write(doc)
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
@@ -479,14 +475,12 @@ impl ser::Serializer for SerializerToYaml {
         Ok(Yaml::Integer(v))
     }
 
-    serde_if_integer128! {
-        #[allow(clippy::cast_possible_truncation)]
-        fn serialize_i128(self, v: i128) -> Result<Yaml> {
-            if v <= i64::max_value() as i128 && v >= i64::min_value() as i128 {
-                self.serialize_i64(v as i64)
-            } else {
-                Ok(Yaml::Real(v.to_string()))
-            }
+    #[allow(clippy::cast_possible_truncation)]
+    fn serialize_i128(self, v: i128) -> Result<Yaml> {
+        if v <= i64::max_value() as i128 && v >= i64::min_value() as i128 {
+            self.serialize_i64(v as i64)
+        } else {
+            Ok(Yaml::Real(v.to_string()))
         }
     }
 
@@ -510,14 +504,12 @@ impl ser::Serializer for SerializerToYaml {
         }
     }
 
-    serde_if_integer128! {
-        #[allow(clippy::cast_possible_truncation)]
-        fn serialize_u128(self, v: u128) -> Result<Yaml> {
-            if v <= i64::max_value() as u128 {
-                self.serialize_i64(v as i64)
-            } else {
-                Ok(Yaml::Real(v.to_string()))
-            }
+    #[allow(clippy::cast_possible_truncation)]
+    fn serialize_u128(self, v: u128) -> Result<Yaml> {
+        if v <= i64::max_value() as u128 {
+            self.serialize_i64(v as i64)
+        } else {
+            Ok(Yaml::Real(v.to_string()))
         }
     }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -3,7 +3,7 @@ use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error as SError, Expected,
     MapAccess, SeqAccess, Unexpected, VariantAccess, Visitor,
 };
-use serde::{forward_to_deserialize_any, serde_if_integer128};
+use serde::forward_to_deserialize_any;
 use std::fmt;
 use std::vec;
 
@@ -212,13 +212,11 @@ impl<'de> Deserializer<'de> for Value {
         self.deserialize_number(visitor)
     }
 
-    serde_if_integer128! {
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_number(visitor)
-        }
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_number(visitor)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -249,13 +247,11 @@ impl<'de> Deserializer<'de> for Value {
         self.deserialize_number(visitor)
     }
 
-    serde_if_integer128! {
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Error>
-        where
-            V: Visitor<'de>,
-        {
-            self.deserialize_number(visitor)
-        }
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_number(visitor)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Error>

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::cast_lossless, clippy::cast_possible_wrap)]
 
 use indoc::indoc;
-use serde::serde_if_integer128;
 use serde_derive::Deserialize;
 use serde_yaml::Value;
 use std::collections::BTreeMap;
@@ -196,26 +195,24 @@ fn test_number_as_string() {
     test_de(yaml, &expected);
 }
 
-serde_if_integer128! {
-    #[test]
-    fn test_i128_big() {
-        let expected: i128 = ::std::i64::MIN as i128 - 1;
-        let yaml = indoc! {"
-            ---
-            -9223372036854775809
-        "};
-        assert_eq!(expected, serde_yaml::from_str::<i128>(yaml).unwrap());
-    }
+#[test]
+fn test_i128_big() {
+    let expected: i128 = ::std::i64::MIN as i128 - 1;
+    let yaml = indoc! {"
+        ---
+        -9223372036854775809
+    "};
+    assert_eq!(expected, serde_yaml::from_str::<i128>(yaml).unwrap());
+}
 
-    #[test]
-    fn test_u128_big() {
-        let expected: u128 = ::std::u64::MAX as u128 + 1;
-        let yaml = indoc! {"
-            ---
-            18446744073709551616
-        "};
-        assert_eq!(expected, serde_yaml::from_str::<u128>(yaml).unwrap());
-    }
+#[test]
+fn test_u128_big() {
+    let expected: u128 = ::std::u64::MAX as u128 + 1;
+    let yaml = indoc! {"
+        ---
+        18446744073709551616
+    "};
+    assert_eq!(expected, serde_yaml::from_str::<u128>(yaml).unwrap());
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -5,7 +5,6 @@
 )]
 
 use indoc::indoc;
-use serde::serde_if_integer128;
 use serde_derive::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::collections::BTreeMap;
@@ -78,26 +77,24 @@ fn test_int_max_i64() {
     test_serde(&thing, yaml);
 }
 
-serde_if_integer128! {
-    #[test]
-    fn test_i128_small() {
-        let thing: i128 = -256;
-        let yaml = indoc! {"
-            ---
-            -256
-        "};
-        test_serde(&thing, yaml);
-    }
+#[test]
+fn test_i128_small() {
+    let thing: i128 = -256;
+    let yaml = indoc! {"
+        ---
+        -256
+    "};
+    test_serde(&thing, yaml);
+}
 
-    #[test]
-    fn test_u128_small() {
-        let thing: u128 = 256;
-        let yaml = indoc! {"
-            ---
-            256
-        "};
-        test_serde(&thing, yaml);
-    }
+#[test]
+fn test_u128_small() {
+    let thing: u128 = 256;
+    let yaml = indoc! {"
+        ---
+        256
+    "};
+    test_serde(&thing, yaml);
 }
 
 #[test]


### PR DESCRIPTION
The oldest rustc that serde-yaml builds with is 1.38. The `u128` and `i128` types are supported by serde on rustc 1.26+ for non-emscripten targets, and 1.40+ for emscripten. I am skeptical that anybody targeting emscripten would be using either 1.38 or 1.39 compilers today in 2021 because the target has matured so much recently, so effectively nobody cares about the non-128 bit codepath.