### PR TITLE
Serialize f32

### DIFF
--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -143,6 +143,28 @@ fn test_float32() {
         25.6
     "};
     test_serde(&thing, yaml);
+
+    let thing = f32::INFINITY;
+    let yaml = indoc! {"
+        ---
+        .inf
+    "};
+    test_serde(&thing, yaml);
+
+    let thing = f32::NEG_INFINITY;
+    let yaml = indoc! {"
+        ---
+        -.inf
+    "};
+    test_serde(&thing, yaml);
+
+    let single_float: f32 = serde_yaml::from_str(indoc! {"
+        ---
+        .nan
+    "})
+    .unwrap();
+    assert!(single_float.is_nan());
+
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -136,6 +136,16 @@ fn test_float() {
 }
 
 #[test]
+fn test_float32() {
+    let thing: f32 = 25.6;
+    let yaml = indoc! {"
+        ---
+        25.6
+    "};
+    test_serde(&thing, yaml);
+}
+
+#[test]
 fn test_vec() {
     let thing = vec![1, 2, 3];
     let yaml = indoc! {"


### PR DESCRIPTION
This change adds explicit formatting for f32 to avoid artifacts when promoting to f64.

Fixes dtolnay/serde-yaml#213