### PR TITLE
Speed up cargo-fuzz install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo install cargo-fuzz --debug
+      - uses: dtolnay/install@cargo-fuzz
       - run: cargo fuzz build -O
         # Currently broken. https://github.com/rust-fuzz/cargo-fuzz/issues/276
         continue-on-error: true


### PR DESCRIPTION
The cargo-fuzz install step formerly took 1m 26s, which dominates the runtime of that workflow. This PR switches to a precompiled signed binary instead, which is &lt;1 second.

**Before:**

![Screenshot from 2021-10-09 01-13-16](https://user-images.githubusercontent.com/1940490/136636713-ba49286f-8679-4d47-a590-334d39571aa5.png)
