### PR TITLE
Fix unit struct to serialize/deserialize in a format similar to the regular structs

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1277,11 +1277,17 @@ impl<'de, 'a, 'r> de::Deserializer<'de> for &'r mut DeserializerFromEvents<'a> {
         self.deserialize_scalar(visitor)
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
+        let (next, _) = self.next()?;
+        match next {
+            Event::Scalar(scalar_name, TScalarStyle::Plain, None) if name == scalar_name => {
+                visitor.visit_unit()
+            }
+            other => Err(invalid_type(other, &visitor)),
+        }
     }
 
     /// Parses a newtype struct as the underlying value.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -556,8 +556,8 @@ impl ser::Serializer for SerializerToYaml {
         Ok(Yaml::Null)
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Yaml> {
-        self.serialize_unit()
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Yaml> {
+        Ok(Yaml::String(name.to_owned()))
     }
 
     fn serialize_unit_variant(

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -330,11 +330,14 @@ impl<'de> Deserializer<'de> for Value {
         }
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
+        match self {
+            Value::String(ref unit_name) if name == unit_name => visitor.visit_unit(),
+            _ => Err(self.invalid_type(&visitor)),
+        }
     }
 
     fn deserialize_newtype_struct<V>(

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -164,7 +164,6 @@ fn test_float32() {
     "})
     .unwrap();
     assert!(single_float.is_nan());
-
 }
 
 #[test]
@@ -269,6 +268,18 @@ fn test_unit() {
         ---
         - ~
         - ~
+    "};
+    test_serde(&thing, yaml);
+}
+
+#[test]
+fn test_unit_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Foo;
+    let thing = Foo;
+    let yaml = indoc! {"
+        ---
+        Foo
     "};
     test_serde(&thing, yaml);
 }


### PR DESCRIPTION
closes https://github.com/dtolnay/serde-yaml/issues/216

I dont really know what im doing but it passes the test I wrote :shrug: 

concerns:
* Do I need more specific error handling or is invalid_type fine?
* is matching on TScalarStyle::Plan and None the correct approach?
* This change to unit struct handling makes sense to me but maybe theres a reason for the old handling?
   + It looks like serde_json does the same thing as the old handling https://github.com/serde-rs/json/blob/2e1c46c89501cbe9edc41d78469ca690bf79ff65/src/de.rs#L1681