### PR TITLE
- Adding support for explicit tag based discriminant for Rust Enum parsing for serde_yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["yaml", "serde"]
 dtoa = "0.4"
 indexmap = "1.5"
 serde = "1.0.69"
-yaml-rust = "0.4.5"
+yaml-rust = {git = "https://github.com/dchakrav-github/yaml-rust"}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,3 +117,4 @@ mod number;
 mod path;
 mod ser;
 mod value;
+

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -155,6 +155,51 @@ fn test_enum_alias() {
 }
 
 #[test]
+fn test_enum_alias_tag_mixed_with_key_based() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    enum E {
+        A,
+        B(u8, u8),
+        C(f64)
+    }
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Data {
+        a: E,
+        b: E,
+        c: E,
+        u: E,
+    }
+    let yaml = indoc! {"
+        ---
+        aref:
+          &aref
+          A
+        bref:
+          &bref
+          B:
+            - 1
+            - 2
+        cref:
+          &cref
+          !C 1.0
+        uref:
+          &uref
+          !A
+        a: *aref
+        b: *bref
+        c: *cref
+        u: *uref
+    "};
+    let expected = Data {
+        a: E::A,
+        b: E::B(1, 2),
+        c: E::C(1.0),
+        u: E::A
+    };
+    test_de(yaml, &expected);
+}
+
+#[test]
 fn test_enum_tag() {
     #[derive(Deserialize, PartialEq, Debug)]
     enum E {

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -133,7 +133,7 @@ fn test_variant_not_a_map() {
         ---
         - "V"
     "#};
-    let expected = "invalid type: sequence, expected string or singleton map at line 2 column 1";
+    let expected = "V: invalid type: sequence, expected usize at line 3 column 1";
     test_error::<E>(yaml, expected);
 }
 
@@ -232,6 +232,25 @@ fn test_invalid_scalar_type() {
     let yaml = "x:\n";
     let expected = "x: invalid type: unit value, expected an array of length 1 at line 2 column 1";
     test_error::<S>(yaml, expected);
+}
+
+#[test]
+fn test_incorrect_variant_by_tag() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum Message {
+        Quit,
+        ChangeColor(i32, i32, i32),
+        Move { x: i32, y: i32 },
+        Write(String),
+        Number(f64)
+    }
+
+    let yaml = indoc! {"\
+        ---
+        !Write
+    "};
+    let expected = "Write: invalid type: unit value, expected a string at line 3 column 1";
+    test_error::<Message>(yaml, &expected);
 }
 
 #[test]


### PR DESCRIPTION
There is being started as a draft PR as there is change needed in yaml_rust implementation for propagation of tags for sequence and mapping start events. The change in yaml_rust address https://github.com/chyh1990/yaml-rust/issues/147 (pending [PR](https://github.com/chyh1990/yaml-rust/pull/180) request filed there. Currently, Cargo.toml points to the public [fork](https://github.com/dchakrav-github/yaml-rust/commit/c202dd0e0172602a101015260a021fb59700f086) where the fix exists. This makes PR local checkout, building and inspecting the work easier), https://github.com/dtolnay/serde-yaml/issues/147, that allows for explicit tags to be used to map to the Enum. 

Please note, this PR explicitly choose **not** to address serialization with explicit tag discriminators. It isn't clear what dependency the consumers of this crate's have on the output serialization format. Can follow up with a separate PR change for Serializer change. @dtolnay seeking your advice on compatibility here. 

Summary of the change:

- Co-change needed in yaml_rust to propagate Tags as a part of Sequence/Mapping Start events to map and use for deserialization
- Fixed scalar mapping to delegate to conversions to handle other primitive types with explicit discriminant. This handles the case of 
```rust
#[derive(Deserialize, PartialEq, Debug)]
    enum E {
        A(String),
        B(String),
        C(f32), // <-- this is new
}
```
when a call is being made for `de::VariantAccess::newtype_variant` it delegate correctly to get the value, see `enum Message` type in `test_de.rs`
- Added unit testing for use cases for passing happy case
- Added unit testing into error case for corner use case