### PR TITLE
Yaml 1.1 octal parsing quirk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
     clippy::must_use_candidate,
 )]
 
-pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
+pub use crate::de::{from_reader, from_slice, from_str, Deserializer, DeserializingQuirks};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{to_string, to_vec, to_writer, Serializer};
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -345,6 +345,16 @@ fn test_numbers() {
 }
 
 #[test]
+fn test_quirk_old_octals() {
+    use serde::Deserialize;
+    let de = serde_yaml::Deserializer::from_str_with_quirks("0777", serde_yaml::DeserializingQuirks {
+        old_octals: true,
+    });
+    let value = u64::deserialize(de).unwrap();
+    assert_eq!(value, 0o777);
+}
+
+#[test]
 fn test_stateful() {
     struct Seed(i64);
 


### PR DESCRIPTION
I dont know how to handle this better, without reimplementing deserialization myself, and i think someone needs this too

Per yaml 1.2 spec, octals should be written as following: `0o123`, however, golang yaml implementation, which is used for a lot of devops stuff, supports octals in `0123` format:
https://github.com/go-yaml/yaml/issues/420

I propose to add optional ability to deserialize octals in same way, because a lot of people expect golang's parser behavior

This setting only supports deserialization, serialization is still performed in standard-complicant way
Fixes: #134
