### PR TITLE
Treat YAML 1.1 style octals with sign as string, not base 10 number

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -987,7 +987,10 @@ where
             return visitor.visit_i64(n);
         }
     }
-    if v.len() > 1 && v.starts_with('0') && v.bytes().all(|b| b.is_ascii_digit()) {
+    if {
+        let v = v.trim_start_matches(&['-', '+'][..]);
+        v.len() > 1 && v.starts_with('0') && v[1..].bytes().all(|b| b.is_ascii_digit())
+    } {
         // After handling the different number encodings above if we are left
         // with leading zero(s) followed by numeric characters this is in fact a
         // string according to the YAML 1.2 spec.

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -339,7 +339,17 @@ fn test_numbers() {
         let value = serde_yaml::from_str::<Value>(yaml).unwrap();
         match value {
             Value::Number(number) => assert_eq!(number.to_string(), expected),
-            _ => panic!("expected number"),
+            _ => panic!("expected number. input={:?}, result={:?}", yaml, value),
+        }
+    }
+
+    // NOT numbers.
+    let cases = ["0127", "+0127", "-0127"];
+    for yaml in &cases {
+        let value = serde_yaml::from_str::<Value>(yaml).unwrap();
+        match value {
+            Value::String(string) => assert_eq!(string, *yaml),
+            _ => panic!("expected string. input={:?}, result={:?}", yaml, value),
         }
     }
 }


### PR DESCRIPTION
Previously we'd treat values like `0127` as correctly a string not a number, per the YAML 1.2 spec. However that check did not kick in when there was a sign: `-0127` or `+0127`, and those would end up getting parsed as a base 10 number via u64::from_str or i64::from_str, which is not correct.