### PR TITLE
Support emitting comments, blocks and alternate integer encodings in serialized output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ryu = "1.0"
 indexmap = "1.5"
 serde = "1.0.69"
 #yaml-rust = "0.4.5"
-yaml-rust = {path = "../yaml-rust"}
+yaml-rust = {git = "https://github.com/cfrantz/yaml-rust", branch="blocks_and_comments"}
 yamlformat_derive = {path = "yamlformat_derive"}
 inventory = "0.2"
 once_cell = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ keywords = ["yaml", "serde"]
 ryu = "1.0"
 indexmap = "1.5"
 serde = "1.0.69"
-yaml-rust = "0.4.5"
+#yaml-rust = "0.4.5"
+yaml-rust = {path = "../yaml-rust"}
+yamlformat_derive = {path = "yamlformat_derive"}
+inventory = "0.2"
+once_cell = "1.9"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub enum ErrorImpl {
     Io(io::Error),
     Utf8(str::Utf8Error),
     FromUtf8(string::FromUtf8Error),
+    Format(String),
 
     EndOfStream,
     MoreThanOneDocument,
@@ -130,6 +131,10 @@ pub(crate) fn string_utf8(err: string::FromUtf8Error) -> Error {
     Error(Box::new(ErrorImpl::FromUtf8(err)))
 }
 
+pub(crate) fn format(err: String) -> Error {
+    Error(Box::new(ErrorImpl::Format(err)))
+}
+
 pub(crate) fn recursion_limit_exceeded() -> Error {
     Error(Box::new(ErrorImpl::RecursionLimitExceeded))
 }
@@ -205,6 +210,7 @@ impl ErrorImpl {
             ErrorImpl::Io(err) => error::Error::description(err),
             ErrorImpl::Utf8(err) => error::Error::description(err),
             ErrorImpl::FromUtf8(err) => error::Error::description(err),
+            ErrorImpl::Format(err) => err.as_str(),
             ErrorImpl::EndOfStream => "EOF while parsing a value",
             ErrorImpl::MoreThanOneDocument => {
                 "deserializing from YAML containing more than one document is not supported"
@@ -241,6 +247,7 @@ impl ErrorImpl {
             ErrorImpl::Io(err) => Display::fmt(err, f),
             ErrorImpl::Utf8(err) => Display::fmt(err, f),
             ErrorImpl::FromUtf8(err) => Display::fmt(err, f),
+            ErrorImpl::Format(err) => Display::fmt(err, f),
             ErrorImpl::EndOfStream => f.write_str("EOF while parsing a value"),
             ErrorImpl::MoreThanOneDocument => f.write_str(
                 "deserializing from YAML containing more than one document is not supported",
@@ -258,6 +265,7 @@ impl ErrorImpl {
             ErrorImpl::Io(io) => f.debug_tuple("Io").field(io).finish(),
             ErrorImpl::Utf8(utf8) => f.debug_tuple("Utf8").field(utf8).finish(),
             ErrorImpl::FromUtf8(from_utf8) => f.debug_tuple("FromUtf8").field(from_utf8).finish(),
+            ErrorImpl::Format(s) => f.debug_tuple("Format").field(s).finish(),
             ErrorImpl::EndOfStream => f.debug_tuple("EndOfStream").finish(),
             ErrorImpl::MoreThanOneDocument => f.debug_tuple("MoreThanOneDocument").finish(),
             ErrorImpl::RecursionLimitExceeded => f.debug_tuple("RecursionLimitExceeded").finish(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,3 +119,4 @@ mod number;
 mod path;
 mod ser;
 mod value;
+pub mod yamlformat;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -294,7 +294,6 @@ where
 pub struct ThenWrite<'a, 'f, W, D> {
     serializer: &'a mut Serializer<'f, W>,
     delegate: D,
-    comment: Option<String>,
 }
 
 impl<'a, 'f, W, D> ThenWrite<'a, 'f, W, D> {
@@ -302,7 +301,6 @@ impl<'a, 'f, W, D> ThenWrite<'a, 'f, W, D> {
         ThenWrite {
             serializer,
             delegate,
-            comment: None,
         }
     }
 }
@@ -572,10 +570,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_i8(self, v: i8) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#08b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#010b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#02x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#03o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#04x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#05o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type i8",
                 self.format
@@ -586,10 +584,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_i16(self, v: i16) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#016b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#018b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#04x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#06o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#06x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#08o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type i16",
                 self.format
@@ -600,10 +598,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_i32(self, v: i32) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#032b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#034b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#08x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#011o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#010x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#013o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type i32",
                 self.format
@@ -614,10 +612,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_i64(self, v: i64) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#064b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#066b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#016x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#022o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#018x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#024o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type i64",
                 self.format
@@ -628,10 +626,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_i128(self, v: i128) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#0128b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#0130}", v))),
             Some(Format::Decimal) => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#032x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#043o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#034x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#045o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type i128",
                 self.format
@@ -642,10 +640,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_u8(self, v: u8) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#08b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#010b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#02x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#03o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#04x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#05o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type u8",
                 self.format
@@ -656,10 +654,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_u16(self, v: u16) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#016b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#018b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#04x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#06o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#06x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#08o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type u16",
                 self.format
@@ -670,10 +668,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_u32(self, v: u32) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#032b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#034b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Integer(v as i64)),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#08x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#011o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#010x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#013o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type u32",
                 self.format
@@ -684,10 +682,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_u64(self, v: u64) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#064b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#066b}", v))),
             Some(Format::Decimal) => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#016x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#022o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#018x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#024o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type u64",
                 self.format
@@ -698,10 +696,10 @@ impl<'f> ser::Serializer for SerializerToYaml<'f> {
     fn serialize_u128(self, v: u128) -> Result<Yaml> {
         match self.format {
             None => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#0128b}", v))),
+            Some(Format::Binary) => Ok(Yaml::Real(format!("{:#0130}", v))),
             Some(Format::Decimal) => Ok(Yaml::Real(v.to_string())),
-            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#032x}", v))),
-            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#043o}", v))),
+            Some(Format::Hex) => Ok(Yaml::Real(format!("{:#034x}", v))),
+            Some(Format::Octal) => Ok(Yaml::Real(format!("{:#045o}", v))),
             _ => Err(error::format(format!(
                 "Format {:?} not supported for type u128",
                 self.format

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -89,7 +89,9 @@ pub fn to_value<T>(value: T) -> Result<Value, Error>
 where
     T: Serialize,
 {
-    value.serialize(SerializerToYaml).map(yaml_to_value)
+    value
+        .serialize(SerializerToYaml::default())
+        .map(yaml_to_value)
 }
 
 /// Interpret a `serde_yaml::Value` as an instance of type `T`.
@@ -621,6 +623,9 @@ fn yaml_to_value(yaml: Yaml) -> Value {
         Yaml::Alias(_) => panic!("alias unsupported"),
         Yaml::Null => Value::Null,
         Yaml::BadValue => panic!("bad value"),
+        Yaml::BlockScalar(_) => panic!("block scalar unexpected"),
+        Yaml::DocFragment(_) => panic!("doc fragment unexpected"),
+        Yaml::Comment(_) => panic!("comment unexpected"),
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -624,7 +624,7 @@ fn yaml_to_value(yaml: Yaml) -> Value {
         Yaml::Null => Value::Null,
         Yaml::BadValue => panic!("bad value"),
         Yaml::BlockScalar(_) => panic!("block scalar unexpected"),
-        Yaml::DocFragment(_) => panic!("doc fragment unexpected"),
+        Yaml::DocFragment(_, _) => panic!("doc fragment unexpected"),
         Yaml::Comment(_) => panic!("comment unexpected"),
     }
 }

--- a/src/yamlformat.rs
+++ b/src/yamlformat.rs
@@ -1,0 +1,109 @@
+//! yaml formatting.
+
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Mutex;
+pub use yamlformat_derive::*;
+
+/// `MemberId` identifies struct fields and enum variants.
+#[derive(Debug)]
+pub enum MemberId<'a> {
+    /// `Name` identifies a named field.
+    Name(&'a str),
+    /// `Index` identifies an tuple field.
+    Index(u32),
+}
+
+/// `Format` describes how a field is to be formatted.
+#[derive(Debug, PartialEq)]
+pub enum Format {
+    /// Format a string field using block formatting.
+    Block,
+    /// Format an integer field as binary.
+    Binary,
+    /// Format an integer field as decimal.
+    Decimal,
+    /// Format an integer field as Hexadecimal.
+    Hex,
+    /// Format an integer field as Octal.
+    Octal,
+}
+
+/// YamlFormat is used by the serializer to choose the desired formatting.
+pub trait YamlFormat {
+    /// Returns the format for a given field.
+    fn format(&self, field: &MemberId) -> Option<Format>;
+    /// Returns the comment associated with a given field.
+    fn comment(&self, field: &MemberId) -> Option<String>;
+}
+
+#[doc(hidden)]
+pub type CastFn = unsafe fn(*const ()) -> &'static dyn YamlFormat;
+
+#[doc(hidden)]
+pub type IdFn = fn() -> usize;
+
+#[doc(hidden)]
+pub struct YamlFormatType {
+    pub id: IdFn,
+    pub reconstitute: CastFn,
+}
+inventory::collect!(YamlFormatType);
+
+impl YamlFormatType {
+    #[doc(hidden)]
+    pub fn of<T>() -> usize
+    where
+        T: ?Sized,
+    {
+        // Just like https://github.com/rust-lang/rust/issues/41875#issuecomment-317292888
+        // We monomorphize on T and then cast the function pointer address of
+        // the monomorphized `YamlFormatType::of` function to an integer identifier.
+        YamlFormatType::of::<T> as usize
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn cast<T>(ptr: *const ()) -> &'static dyn YamlFormat
+    where
+        T: 'static + YamlFormat,
+    {
+        // Cast a generic pointer back to a reference to T and return a dyn
+        // reference to the YamlFormat trait.
+        &*(ptr as *const T)
+    }
+
+    fn lookup(id: usize) -> Option<CastFn> {
+        static TYPEMAP: OnceCell<Mutex<HashMap<usize, CastFn>>> = OnceCell::new();
+        let typemap = TYPEMAP
+            .get_or_init(|| {
+                let mut types = HashMap::new();
+                // Iterate over all registered YamlFormatTypes and store them in
+                // a HashMap for fast access.
+                for yf in inventory::iter::<YamlFormatType> {
+                    types.insert((yf.id)(), yf.reconstitute);
+                }
+                Mutex::new(types)
+            })
+            .lock()
+            .unwrap();
+        typemap.get(&id).cloned()
+    }
+
+    #[doc(hidden)]
+    pub fn get<'a, T>(object: &'a T) -> Option<&'a dyn YamlFormat>
+    where
+        T: ?Sized,
+    {
+        // Get the type-id of `object` and cast it back to a YamlFormat
+        // if we can.
+        let id = Self::of::<T>();
+        Self::lookup(id).map(|reconstitute| unsafe {
+            // Shorten the lifetime to 'a, as the dyn YamlFormat reference is
+            // really a reinterpretation of `object`, which has lifetime 'a.
+            std::mem::transmute::<&'static dyn YamlFormat, &'a dyn YamlFormat>(reconstitute(
+                object as *const T as *const (),
+            ))
+        })
+    }
+}

--- a/src/yamlformat.rs
+++ b/src/yamlformat.rs
@@ -11,8 +11,10 @@ pub use yamlformat_derive::*;
 pub enum MemberId<'a> {
     /// `Name` identifies a named field.
     Name(&'a str),
-    /// `Index` identifies an tuple field.
+    /// `Index` identifies a tuple field.
     Index(u32),
+    /// `Variant` identifies a variant wihin an enum.
+    Variant,
 }
 
 /// `Format` describes how a field is to be formatted.
@@ -28,14 +30,16 @@ pub enum Format {
     Hex,
     /// Format an integer field as Octal.
     Octal,
+    /// Format hashes and arrays on one line.
+    Oneline,
 }
 
 /// YamlFormat is used by the serializer to choose the desired formatting.
 pub trait YamlFormat {
     /// Returns the format for a given field.
-    fn format(&self, field: &MemberId) -> Option<Format>;
+    fn format(&self, variant: Option<&str>, field: &MemberId) -> Option<Format>;
     /// Returns the comment associated with a given field.
-    fn comment(&self, field: &MemberId) -> Option<String>;
+    fn comment(&self, variant: Option<&str>, field: &MemberId) -> Option<String>;
 }
 
 #[doc(hidden)]

--- a/src/yamlformat.rs
+++ b/src/yamlformat.rs
@@ -1,7 +1,6 @@
 //! yaml formatting.
 
 use once_cell::sync::OnceCell;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Mutex;
 pub use yamlformat_derive::*;

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use serde_derive::{Deserialize, Serialize};
+use serde_yaml::yamlformat::YamlFormat;
+
+// Numbers in different bases, static comments.
+#[derive(Serialize, YamlFormat)]
+struct Coordinate {
+    #[yaml(format=hex, comment="X-coordinate")]
+    x: u32,
+    #[yaml(format=dec, comment="Y-coordinate")]
+    y: u32,
+    #[yaml(format=oct, comment="Z-coordinate")]
+    z: u32,
+}
+
+// Text blocks, comments a fields within the struct.
+#[derive(Serialize, YamlFormat)]
+struct Gettysburg {
+    author: &'static str,
+
+    #[yaml(format=block, comment=_prelude)]
+    prelude: &'static str,
+    #[serde(skip)]
+    _prelude: &'static str,
+
+    #[yaml(format=block, comment=_middle)]
+    middle: &'static str,
+    #[serde(skip)]
+    _middle: &'static str,
+
+    #[yaml(format=block, comment=_end)]
+    end: &'static str,
+    #[serde(skip)]
+    _end: &'static str,
+}
+
+#[test]
+fn test_coordinate() -> Result<()> {
+    let foo = Coordinate { x: 16, y: 10, z: 8 };
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}
+
+#[test]
+fn test_gettysburg() -> Result<()> {
+    let foo = Gettysburg {
+        // Note: trailing newline should cause a "|+" block.
+        prelude: r#"Four score and seven years ago our fathers brought forth on this
+continent, a new nation, conceived in Liberty, and dedicated to the
+proposition that all men are created equal.
+"#,
+        _prelude: "Bliss copy",
+
+        // Note: trailing newline should cause a "|+" block.
+        middle: r#"Now we are engaged in a great civil war, testing whether that nation,
+or any nation so conceived, and so dedicated, can long endure. We are met
+on a great battle field of that war. We come to dedicate a portion of it,
+as a final resting place for those who died here, that the nation might
+live. This we may, in all propriety do.
+"#,
+        _middle: "Nicolay Copy",
+
+        // Note: NO trailing newline should cause a "|-" block.
+        end: r#"But in a larger sense, we can not dedicate we can not consecrate we can
+not hallow this ground. The brave men, living and dead, who struggled
+here, have consecrated it far above our poor power to add or detract. The
+world will little note, nor long remember, what we say here, but can
+never forget what they did here.
+
+It is for us, the living, rather to be dedicated here to the unfinished
+work which they have, thus far, so nobly carried on. It is rather for
+us to be here dedicated to the great task remaining before us that from
+these honored dead we take increased devotion to that cause for which
+they gave the last full measure of devotion that we here highly resolve
+that these dead shall not have died in vain; that this nation shall
+have a new birth of freedom; and that this government of the people,
+by the people, for the people, shall not perish from the earth."#,
+        _end: "Hay Copy",
+
+        author: "Abraham Lincoln",
+    };
+
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}
+
+// A containing struct which does not implement YamlFormat.
+#[derive(Serialize)]
+struct Sfdp {
+    header: SfdpHeader,
+}
+
+// Numbers in different bases, comments from functions within the impl.
+#[derive(Serialize, YamlFormat)]
+struct SfdpHeader {
+    #[yaml(format=hex, comment=_signature())]
+    signature: u32,
+    #[yaml(comment = "SFDP version")]
+    minor: u8,
+    major: u8,
+    #[yaml(comment = "Number of parameter headers minus 1")]
+    nph: u8,
+    #[yaml(format=bin, comment="Reserved field should be all ones")]
+    reserved: u8,
+}
+
+impl SfdpHeader {
+    fn _signature(&self) -> Option<String> {
+        Some(format!(
+            "Signature value='{}' (should be 'SFDP')",
+            self.signature
+                .to_le_bytes()
+                .map(|b| char::from(b).to_string())
+                .join("")
+        ))
+    }
+}
+
+#[test]
+fn test_sfdp() -> Result<()> {
+    let foo = Sfdp {
+        header: SfdpHeader {
+            signature: 0x50444653,
+            minor: 6,
+            major: 1,
+            nph: 2,
+            reserved: 255,
+        },
+    };
+    println!("foo.header={:p}", &foo.header);
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -3,7 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_yaml::yamlformat::YamlFormat;
 
 // Numbers in different bases, static comments.
-#[derive(Serialize, YamlFormat)]
+#[derive(Serialize, Deserialize, YamlFormat, Debug, PartialEq)]
 struct Coordinate {
     #[yaml(format=hex, comment="X-coordinate")]
     x: u32,
@@ -13,44 +13,86 @@ struct Coordinate {
     z: u32,
 }
 
+const COORDINATE: &str = r#"---
+# X-coordinate
+x: 0x00000010
+# Y-coordinate
+y: 10
+# Z-coordinate
+z: 0o00000000010
+"#;
+
 #[test]
 fn test_coordinate() -> Result<()> {
-    let foo = Coordinate { x: 16, y: 10, z: 8 };
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
+    let val = Coordinate { x: 16, y: 10, z: 8 };
+    let s = serde_yaml::to_string(&val)?;
+    let d = serde_yaml::from_str::<Coordinate>(&s)?;
+    assert_eq!(s, COORDINATE);
+    assert_eq!(d, val);
     Ok(())
 }
 
 // Text blocks, comments a fields within the struct.
-#[derive(Serialize, YamlFormat)]
+#[derive(Serialize, Deserialize, YamlFormat, Debug, PartialEq)]
 struct Gettysburg {
-    author: &'static str,
+    author: String,
 
     #[yaml(format=block, comment=_prelude)]
-    prelude: &'static str,
+    prelude: String,
     #[serde(skip)]
-    _prelude: &'static str,
+    _prelude: String,
 
     #[yaml(format=block, comment=_middle)]
-    middle: &'static str,
+    middle: String,
     #[serde(skip)]
-    _middle: &'static str,
+    _middle: String,
 
     #[yaml(format=block, comment=_end)]
-    end: &'static str,
+    end: String,
     #[serde(skip)]
-    _end: &'static str,
+    _end: String,
 }
+
+const GETTYSBURG: &str = r#"---
+author: Abraham Lincoln
+# Hay copy
+prelude: |+
+  Four score and seven years ago our fathers brought forth, upon this
+  continent, a new nation, conceived in Liberty, and dedicated to the
+  proposition that all men are created equal.
+# Nicolay Copy
+middle: |+
+  Now we are engaged in a great civil war, testing whether that nation,
+  or any nation so conceived, and so dedicated, can long endure. We are met
+  on a great battle field of that war. We come to dedicate a portion of it,
+  as a final resting place for those who died here, that the nation might
+  live. This we may, in all propriety do.
+# Bliss Copy
+end: |-
+  But, in a larger sense, we can not dedicate -- we can not consecrate --
+  we can not hallow -- this ground. The brave men, living and dead, who
+  struggled here, have consecrated it, far above our poor power to add or
+  detract. The world will little note, nor long remember what we say here,
+  but it can never forget what they did here. It is for us the living,
+  rather, to be dedicated here to the unfinished work which they who
+  fought here have thus far so nobly advanced. It is rather for us to be
+  here dedicated to the great task remaining before us -- that from these
+  honored dead we take increased devotion to that cause for which they gave
+  the last full measure of devotion -- that we here highly resolve that
+  these dead shall not have died in vain -- that this nation, under God,
+  shall have a new birth of freedom -- and that government of the people,
+  by the people, for the people, shall not perish from the earth.
+"#;
 
 #[test]
 fn test_gettysburg() -> Result<()> {
-    let foo = Gettysburg {
+    let mut val = Gettysburg {
         // Note: trailing newline should cause a "|+" block.
         prelude: r#"Four score and seven years ago our fathers brought forth, upon this
 continent, a new nation, conceived in Liberty, and dedicated to the
 proposition that all men are created equal.
-"#,
-        _prelude: "Hay copy",
+"#.to_string(),
+        _prelude: "Hay copy".to_string(),
 
         // Note: trailing newline should cause a "|+" block.
         middle: r#"Now we are engaged in a great civil war, testing whether that nation,
@@ -58,8 +100,8 @@ or any nation so conceived, and so dedicated, can long endure. We are met
 on a great battle field of that war. We come to dedicate a portion of it,
 as a final resting place for those who died here, that the nation might
 live. This we may, in all propriety do.
-"#,
-        _middle: "Nicolay Copy",
+"#.to_string(),
+        _middle: "Nicolay Copy".to_string(),
 
         // Note: NO trailing newline should cause a "|-" block.
         end: r#"But, in a larger sense, we can not dedicate -- we can not consecrate --
@@ -74,25 +116,32 @@ honored dead we take increased devotion to that cause for which they gave
 the last full measure of devotion -- that we here highly resolve that
 these dead shall not have died in vain -- that this nation, under God,
 shall have a new birth of freedom -- and that government of the people,
-by the people, for the people, shall not perish from the earth."#,
-        _end: "Bliss Copy",
+by the people, for the people, shall not perish from the earth."#.to_string(),
+        _end: "Bliss Copy".to_string(),
 
-        author: "Abraham Lincoln",
+        author: "Abraham Lincoln".to_string(),
     };
 
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
+    let s = serde_yaml::to_string(&val)?;
+    let d = serde_yaml::from_str::<Gettysburg>(&s)?;
+    assert_eq!(s, GETTYSBURG);
+
+    // The deserialized struct will have empty strings in the comment fields.
+    val._prelude = String::default();
+    val._middle = String::default();
+    val._end = String::default();
+    assert_eq!(d, val);
     Ok(())
 }
 
 // A containing struct which does not implement YamlFormat.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Sfdp {
     header: SfdpHeader,
 }
 
 // Numbers in different bases, comments from functions within the impl.
-#[derive(Serialize, YamlFormat)]
+#[derive(Serialize, Deserialize, YamlFormat, Debug, PartialEq)]
 struct SfdpHeader {
     #[yaml(format=hex, comment=_signature())]
     signature: u32,
@@ -117,9 +166,23 @@ impl SfdpHeader {
     }
 }
 
+
+const SFDP: &str  = r#"---
+header:
+  # Signature value='SFDP' (should be 'SFDP')
+  signature: 0x50444653
+  # SFDP version
+  minor: 6
+  major: 1
+  # Number of parameter headers minus 1
+  nph: 2
+  # Reserved field should be all ones
+  reserved: 0b11111111
+"#;
+
 #[test]
 fn test_sfdp() -> Result<()> {
-    let foo = Sfdp {
+    let val = Sfdp {
         header: SfdpHeader {
             signature: 0x50444653,
             minor: 6,
@@ -128,26 +191,37 @@ fn test_sfdp() -> Result<()> {
             reserved: 255,
         },
     };
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
+    let s = serde_yaml::to_string(&val)?;
+    let d = serde_yaml::from_str::<Sfdp>(&s)?;
+    assert_eq!(s, SFDP);
+    assert_eq!(d, val);
     Ok(())
 }
 
-#[derive(Serialize, YamlFormat)]
+#[derive(Serialize, Deserialize, YamlFormat, Debug, PartialEq)]
 struct IntelWord(
     #[yaml(format=hex, comment="MSB")] u8,
     #[yaml(format=hex, comment="LSB")] u8,
 );
 
+const INTEL_WORD: &str = r#"---
+# MSB
+- 0x80
+# LSB
+- 0x01
+"#;
+
 #[test]
 fn test_intel_word() -> Result<()> {
-    let foo = IntelWord(0x80, 0x01);
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
+    let val = IntelWord(0x80, 0x01);
+    let s = serde_yaml::to_string(&val)?;
+    let d = serde_yaml::from_str::<IntelWord>(&s)?;
+    assert_eq!(s, INTEL_WORD);
+    assert_eq!(d, val);
     Ok(())
 }
 
-#[derive(Serialize, YamlFormat)]
+#[derive(Serialize, Deserialize, YamlFormat, Debug, PartialEq)]
 enum NesAddress {
     #[yaml(format=oneline, comment="NES file offset")]
     File(u32),
@@ -157,21 +231,34 @@ enum NesAddress {
     Chr(#[yaml(format=hex)] u8, #[yaml(format=hex)] u16),
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Addresses {
     a: NesAddress,
     b: NesAddress,
     c: NesAddress,
 }
 
+// Note: there is an extra space after the `a` and `b` key fields.
+const ADDRESSES: &str = r#"---
+a: 
+  # NES file offset
+  {"File": 16400}
+b: 
+  # NES PRG bank:address
+  {"Prg": [0x01, 0x8000]}
+c: {"Chr": [0x00, 0x1000]}
+"#;
+
 #[test]
 fn test_nes_address() -> Result<()> {
-    let foo = Addresses {
+    let val = Addresses {
         a: NesAddress::File(0x4010),
         b: NesAddress::Prg(1, 0x8000),
         c: NesAddress::Chr(0, 0x1000),
     };
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
+    let s = serde_yaml::to_string(&val)?;
+    let d = serde_yaml::from_str::<Addresses>(&s)?;
+    assert_eq!(s, ADDRESSES);
+    assert_eq!(d, val);
     Ok(())
 }

--- a/tests/test_format.rs
+++ b/tests/test_format.rs
@@ -13,6 +13,14 @@ struct Coordinate {
     z: u32,
 }
 
+#[test]
+fn test_coordinate() -> Result<()> {
+    let foo = Coordinate { x: 16, y: 10, z: 8 };
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}
+
 // Text blocks, comments a fields within the struct.
 #[derive(Serialize, YamlFormat)]
 struct Gettysburg {
@@ -35,22 +43,14 @@ struct Gettysburg {
 }
 
 #[test]
-fn test_coordinate() -> Result<()> {
-    let foo = Coordinate { x: 16, y: 10, z: 8 };
-    let s = serde_yaml::to_string(&foo)?;
-    println!("{}", s);
-    Ok(())
-}
-
-#[test]
 fn test_gettysburg() -> Result<()> {
     let foo = Gettysburg {
         // Note: trailing newline should cause a "|+" block.
-        prelude: r#"Four score and seven years ago our fathers brought forth on this
+        prelude: r#"Four score and seven years ago our fathers brought forth, upon this
 continent, a new nation, conceived in Liberty, and dedicated to the
 proposition that all men are created equal.
 "#,
-        _prelude: "Bliss copy",
+        _prelude: "Hay copy",
 
         // Note: trailing newline should cause a "|+" block.
         middle: r#"Now we are engaged in a great civil war, testing whether that nation,
@@ -62,21 +62,20 @@ live. This we may, in all propriety do.
         _middle: "Nicolay Copy",
 
         // Note: NO trailing newline should cause a "|-" block.
-        end: r#"But in a larger sense, we can not dedicate we can not consecrate we can
-not hallow this ground. The brave men, living and dead, who struggled
-here, have consecrated it far above our poor power to add or detract. The
-world will little note, nor long remember, what we say here, but can
-never forget what they did here.
-
-It is for us, the living, rather to be dedicated here to the unfinished
-work which they have, thus far, so nobly carried on. It is rather for
-us to be here dedicated to the great task remaining before us that from
-these honored dead we take increased devotion to that cause for which
-they gave the last full measure of devotion that we here highly resolve
-that these dead shall not have died in vain; that this nation shall
-have a new birth of freedom; and that this government of the people,
+        end: r#"But, in a larger sense, we can not dedicate -- we can not consecrate --
+we can not hallow -- this ground. The brave men, living and dead, who
+struggled here, have consecrated it, far above our poor power to add or
+detract. The world will little note, nor long remember what we say here,
+but it can never forget what they did here. It is for us the living,
+rather, to be dedicated here to the unfinished work which they who
+fought here have thus far so nobly advanced. It is rather for us to be
+here dedicated to the great task remaining before us -- that from these
+honored dead we take increased devotion to that cause for which they gave
+the last full measure of devotion -- that we here highly resolve that
+these dead shall not have died in vain -- that this nation, under God,
+shall have a new birth of freedom -- and that government of the people,
 by the people, for the people, shall not perish from the earth."#,
-        _end: "Hay Copy",
+        _end: "Bliss Copy",
 
         author: "Abraham Lincoln",
     };
@@ -129,7 +128,49 @@ fn test_sfdp() -> Result<()> {
             reserved: 255,
         },
     };
-    println!("foo.header={:p}", &foo.header);
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}
+
+#[derive(Serialize, YamlFormat)]
+struct IntelWord(
+    #[yaml(format=hex, comment="MSB")] u8,
+    #[yaml(format=hex, comment="LSB")] u8,
+);
+
+#[test]
+fn test_intel_word() -> Result<()> {
+    let foo = IntelWord(0x80, 0x01);
+    let s = serde_yaml::to_string(&foo)?;
+    println!("{}", s);
+    Ok(())
+}
+
+#[derive(Serialize, YamlFormat)]
+enum NesAddress {
+    #[yaml(format=oneline, comment="NES file offset")]
+    File(u32),
+    #[yaml(format=oneline, comment="NES PRG bank:address")]
+    Prg(#[yaml(format=hex)] u8, #[yaml(format=hex)] u16),
+    #[yaml(format=oneline)]
+    Chr(#[yaml(format=hex)] u8, #[yaml(format=hex)] u16),
+}
+
+#[derive(Serialize)]
+struct Addresses {
+    a: NesAddress,
+    b: NesAddress,
+    c: NesAddress,
+}
+
+#[test]
+fn test_nes_address() -> Result<()> {
+    let foo = Addresses {
+        a: NesAddress::File(0x4010),
+        b: NesAddress::Prg(1, 0x8000),
+        c: NesAddress::Chr(0, 0x1000),
+    };
     let s = serde_yaml::to_string(&foo)?;
     println!("{}", s);
     Ok(())

--- a/yamlformat_derive/Cargo.toml
+++ b/yamlformat_derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "yamlformat_derive"
+version = "0.0.0"
+authors = ["Chris Frantz <frantzcj@gmail.com>"]
+edition = "2018"
+#rust-version = "1.38"
+license = "MIT OR Apache-2.0"
+description = "YAML format for serde-yaml"
+keywords = ["yaml", "serde"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+proc-macro-error = "1.0"
+quote = "1.0"
+syn = {version="1.0", features=["extra-traits"]}

--- a/yamlformat_derive/src/ast.rs
+++ b/yamlformat_derive/src/ast.rs
@@ -1,0 +1,124 @@
+use crate::attr::{self, Attrs};
+use proc_macro2::Span;
+use syn::{
+    Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Ident, Index, Member, Result, Type,
+};
+
+#[derive(Debug)]
+pub enum Input<'a> {
+    Struct(Struct<'a>),
+    Enum(Enum<'a>),
+}
+
+#[derive(Debug)]
+pub struct Struct<'a> {
+    pub original: &'a DeriveInput,
+    pub attrs: Attrs<'a>,
+    pub ident: Ident,
+    pub fields: Vec<Field<'a>>,
+}
+
+#[derive(Debug)]
+pub struct Field<'a> {
+    pub original: &'a syn::Field,
+    pub attrs: Attrs<'a>,
+    pub member: Member,
+    pub ty: &'a Type,
+}
+
+#[derive(Debug)]
+pub struct Enum<'a> {
+    pub original: &'a DeriveInput,
+    pub attrs: Attrs<'a>,
+    pub ident: Ident,
+    pub variants: Vec<Variant<'a>>,
+}
+
+#[derive(Debug)]
+pub struct Variant<'a> {
+    pub original: &'a syn::Variant,
+    pub attrs: Attrs<'a>,
+    pub ident: Ident,
+    pub fields: Vec<Field<'a>>,
+}
+
+impl<'a> Input<'a> {
+    pub fn from_syn(node: &'a DeriveInput) -> Result<Self> {
+        match &node.data {
+            Data::Struct(data) => Struct::from_syn(node, data).map(Input::Struct),
+            Data::Enum(data) => Enum::from_syn(node, data).map(Input::Enum),
+            Data::Union(_) => Err(Error::new_spanned(node, "unions are not supported")),
+        }
+    }
+}
+
+impl<'a> Struct<'a> {
+    fn from_syn(node: &'a DeriveInput, data: &'a DataStruct) -> Result<Self> {
+        let attrs = attr::get(&node.attrs)?;
+        let span = Span::call_site();
+        let fields = Field::multiple_from_syn(&data.fields, span)?;
+        Ok(Struct {
+            original: node,
+            attrs: attrs,
+            ident: node.ident.clone(),
+            fields: fields,
+        })
+    }
+}
+
+impl<'a> Enum<'a> {
+    fn from_syn(node: &'a DeriveInput, data: &'a DataEnum) -> Result<Self> {
+        let attrs = attr::get(&node.attrs)?;
+        let span = Span::call_site();
+        let variants = data
+            .variants
+            .iter()
+            .map(|node| {
+                let v = Variant::from_syn(node, span)?;
+                Ok(v)
+            })
+            .collect::<Result<_>>()?;
+        Ok(Enum {
+            original: node,
+            attrs: attrs,
+            ident: node.ident.clone(),
+            variants: variants,
+        })
+    }
+}
+
+impl<'a> Field<'a> {
+    fn multiple_from_syn(fields: &'a Fields, span: Span) -> Result<Vec<Self>> {
+        fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Field::from_syn(i, field, span))
+            .collect()
+    }
+
+    fn from_syn(i: usize, node: &'a syn::Field, span: Span) -> Result<Self> {
+        Ok(Field {
+            original: node,
+            attrs: attr::get(&node.attrs)?,
+            member: node.ident.clone().map(Member::Named).unwrap_or_else(|| {
+                Member::Unnamed(Index {
+                    index: i as u32,
+                    span,
+                })
+            }),
+            ty: &node.ty,
+        })
+    }
+}
+
+impl<'a> Variant<'a> {
+    fn from_syn(node: &'a syn::Variant, span: Span) -> Result<Self> {
+        let attrs = attr::get(&node.attrs)?;
+        Ok(Variant {
+            original: node,
+            attrs: attrs,
+            ident: node.ident.clone(),
+            fields: Field::multiple_from_syn(&node.fields, span)?,
+        })
+    }
+}

--- a/yamlformat_derive/src/attr.rs
+++ b/yamlformat_derive/src/attr.rs
@@ -1,0 +1,103 @@
+use syn::parse::ParseStream;
+use syn::{parenthesized, token, Attribute, Error, Ident, LitStr, Result, Token};
+
+#[derive(Debug, PartialEq)]
+pub enum Format {
+    None,
+    Block,
+    Binary,
+    Decimal,
+    Hex,
+    Octal,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Comment {
+    None,
+    Field(Ident),
+    Function(Ident),
+    Static(String),
+}
+
+#[derive(Debug)]
+pub struct Attrs<'a> {
+    pub yaml: Option<&'a Attribute>,
+    pub format: Format,
+    pub comment: Comment,
+}
+
+pub fn get(input: &[Attribute]) -> Result<Attrs> {
+    let mut attrs = Attrs {
+        yaml: None,
+        format: Format::None,
+        comment: Comment::None,
+    };
+
+    for attr in input {
+        if attr.path.is_ident("yaml") {
+            attrs.yaml = Some(attr);
+            parse_yaml_attribute(&mut attrs, attr)?;
+        }
+    }
+    Ok(attrs)
+}
+
+fn function_call(input: ParseStream) -> Result<bool> {
+    let content;
+    let result = parenthesized!(content in input);
+    Ok(content.is_empty())
+}
+
+fn parse_yaml_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Result<()> {
+    syn::custom_keyword!(format);
+    syn::custom_keyword!(comment);
+
+    attr.parse_args_with(|input: ParseStream| {
+        let mut more = true;
+        while more {
+            if input.peek(format) {
+                let _kw = input.parse::<format>()?;
+                let _eq: Token![=] = input.parse()?;
+                let ident: Ident = input.parse()?;
+                let istr = ident.to_string();
+                let format = match istr.as_str() {
+                    "block" => Format::Block,
+                    "bin" => Format::Binary,
+                    "dec" => Format::Decimal,
+                    "oct" => Format::Octal,
+                    "hex" => Format::Hex,
+                    _ => Format::None,
+                };
+                if format == Format::None {
+                    return Err(Error::new_spanned(attr, "unknown yamlformat type"));
+                }
+                attrs.format = format;
+            } else if input.peek(comment) {
+                let _kw = input.parse::<comment>()?;
+                let _eq: Token![=] = input.parse()?;
+                if input.peek(Ident) {
+                    let ident: Ident = input.parse()?;
+                    let func = function_call(input);
+                    attrs.comment = match func {
+                        Ok(true) => Comment::Function(ident.clone()),
+                        Ok(false) => {
+                            return Err(Error::new_spanned(attr, "Function args not permitted"));
+                        }
+                        Err(_) => Comment::Field(ident.clone()),
+                    };
+                    return Ok(());
+                }
+                let comment: LitStr = input.parse()?;
+                attrs.comment = Comment::Static(comment.value());
+            } else {
+                return Err(Error::new_spanned(attr, "parse error"));
+            }
+
+            more = input.peek(Token![,]);
+            if more {
+                let _comma: Token![,] = input.parse()?;
+            }
+        }
+        Ok(())
+    })
+}

--- a/yamlformat_derive/src/attr.rs
+++ b/yamlformat_derive/src/attr.rs
@@ -9,6 +9,7 @@ pub enum Format {
     Decimal,
     Hex,
     Octal,
+    Oneline,
 }
 
 #[derive(Debug, PartialEq)]
@@ -66,6 +67,7 @@ fn parse_yaml_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Resul
                     "dec" => Format::Decimal,
                     "oct" => Format::Octal,
                     "hex" => Format::Hex,
+                    "oneline" => Format::Oneline,
                     _ => Format::None,
                 };
                 if format == Format::None {
@@ -85,10 +87,10 @@ fn parse_yaml_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Resul
                         }
                         Err(_) => Comment::Field(ident.clone()),
                     };
-                    return Ok(());
+                } else {
+                    let comment: LitStr = input.parse()?;
+                    attrs.comment = Comment::Static(comment.value());
                 }
-                let comment: LitStr = input.parse()?;
-                attrs.comment = Comment::Static(comment.value());
             } else {
                 return Err(Error::new_spanned(attr, "parse error"));
             }
@@ -96,6 +98,7 @@ fn parse_yaml_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Resul
             more = input.peek(Token![,]);
             if more {
                 let _comma: Token![,] = input.parse()?;
+                more = !input.is_empty();
             }
         }
         Ok(())

--- a/yamlformat_derive/src/attr.rs
+++ b/yamlformat_derive/src/attr.rs
@@ -1,5 +1,5 @@
 use syn::parse::ParseStream;
-use syn::{parenthesized, token, Attribute, Error, Ident, LitStr, Result, Token};
+use syn::{parenthesized, Attribute, Error, Ident, LitStr, Result, Token};
 
 #[derive(Debug, PartialEq)]
 pub enum Format {
@@ -45,7 +45,7 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
 
 fn function_call(input: ParseStream) -> Result<bool> {
     let content;
-    let result = parenthesized!(content in input);
+    let _result = parenthesized!(content in input);
     Ok(content.is_empty())
 }
 

--- a/yamlformat_derive/src/expand.rs
+++ b/yamlformat_derive/src/expand.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Enum, Field, Input, Struct, Variant};
-use crate::attr::{Comment, Format};
+use crate::attr::{Attrs, Comment, Format};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Index, Member, Result};
@@ -13,18 +13,23 @@ pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
     })
 }
 
+fn impl_format(a: &Attrs) -> TokenStream {
+    match &a.format {
+        Format::None => quote! { None },
+        Format::Block => quote! { Some(Format::Block) },
+        Format::Binary => quote! { Some(Format::Binary) },
+        Format::Decimal => quote! { Some(Format::Decimal) },
+        Format::Hex => quote! { Some(Format::Hex) },
+        Format::Octal => quote! { Some(Format::Octal) },
+        Format::Oneline => quote! { Some(Format::Oneline) },
+    }
+}
+
 fn impl_field_format(fields: &[Field]) -> Vec<TokenStream> {
     fields
         .iter()
         .map(|f| {
-            let format = match &f.attrs.format {
-                Format::None => quote! { None },
-                Format::Block => quote! { Some(Format::Block) },
-                Format::Binary => quote! { Some(Format::Binary) },
-                Format::Decimal => quote! { Some(Format::Decimal) },
-                Format::Hex => quote! { Some(Format::Hex) },
-                Format::Octal => quote! { Some(Format::Octal) },
-            };
+            let format = impl_format(&f.attrs);
             match &f.member {
                 Member::Named(id) => {
                     let id = id.to_string();
@@ -38,22 +43,26 @@ fn impl_field_format(fields: &[Field]) -> Vec<TokenStream> {
         .collect::<Vec<_>>()
 }
 
+fn impl_comment(a: &Attrs) -> TokenStream {
+    match &a.comment {
+        Comment::None => quote! { None },
+        Comment::Static(s) => quote! {
+            Some(#s.to_string())
+        },
+        Comment::Field(id) => quote! {
+            Some(self.#id.to_string())
+        },
+        Comment::Function(id) => quote! {
+            self.#id()
+        },
+    }
+}
+
 fn impl_field_comment(fields: &[Field]) -> Vec<TokenStream> {
     fields
         .iter()
         .map(|f| {
-            let comment = match &f.attrs.comment {
-                Comment::None => quote! { None },
-                Comment::Static(s) => quote! {
-                    Some(#s.to_string())
-                },
-                Comment::Field(id) => quote! {
-                    Some(self.#id.to_string())
-                },
-                Comment::Function(id) => quote! {
-                    self.#id()
-                },
-            };
+            let comment = impl_comment(&f.attrs);
             match &f.member {
                 Member::Named(id) => {
                     let id = id.to_string();
@@ -67,11 +76,45 @@ fn impl_field_comment(fields: &[Field]) -> Vec<TokenStream> {
         .collect::<Vec<_>>()
 }
 
+fn impl_variants(variants: &[Variant]) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    let formats = variants
+        .iter()
+        .map(|v| {
+            let variant = v.ident.to_string();
+            let formats = impl_field_format(&v.fields);
+            let vformat = impl_format(&v.attrs);
+            quote! {
+                #variant => match field {
+                    MemberId::Variant => #vformat,
+                    #(#formats),*,
+                    _ => None,
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    let comments = variants
+        .iter()
+        .map(|v| {
+            let variant = v.ident.to_string();
+            let comments = impl_field_comment(&v.fields);
+            let vcomment = impl_comment(&v.attrs);
+            quote! {
+                #variant => match field {
+                    MemberId::Variant => #vcomment,
+                    #(#comments),*,
+                    _ => None,
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    (formats, comments)
+}
+
 fn impl_struct(input: Struct) -> TokenStream {
     let formats = impl_field_format(&input.fields);
     let comments = impl_field_comment(&input.fields);
     let name = &input.ident;
-    let namestr = name.to_string();
     quote! {
         const _: () = {
             extern crate serde_yaml;
@@ -79,13 +122,13 @@ fn impl_struct(input: Struct) -> TokenStream {
             use serde_yaml::yamlformat::{YamlFormat, YamlFormatType, Format, MemberId};
 
             impl YamlFormat for #name {
-                fn format(&self, field: &MemberId) -> Option<Format> {
+                fn format(&self, _variant: Option<&str>, field: &MemberId) -> Option<Format> {
                     match field {
                         #(#formats),*,
                         _ => None,
                     }
                 }
-                fn comment(&self, field: &MemberId) -> Option<String> {
+                fn comment(&self, _variant: Option<&str>, field: &MemberId) -> Option<String> {
                     match field {
                         #(#comments),*,
                         _ => None,
@@ -108,9 +151,48 @@ fn impl_struct(input: Struct) -> TokenStream {
             }
         };
     }
+
 }
 
 fn impl_enum(input: Enum) -> TokenStream {
-    println!("{:?}", input);
-    quote! {}
+    let (formats, comments) = impl_variants(&input.variants);
+    let name = &input.ident;
+    quote! {
+        const _: () = {
+            extern crate serde_yaml;
+            extern crate inventory;
+            use serde_yaml::yamlformat::{YamlFormat, YamlFormatType, Format, MemberId};
+
+            impl YamlFormat for #name {
+                fn format(&self, variant: Option<&str>, field: &MemberId) -> Option<Format> {
+                    let variant = variant?;
+                    match variant {
+                        #(#formats),*,
+                        _ => None,
+                    }
+                }
+                fn comment(&self, variant: Option<&str>, field: &MemberId) -> Option<String> {
+                    let variant = variant?;
+                    match variant {
+                        #(#comments),*,
+                        _ => None,
+                    }
+                }
+            }
+            impl #name {
+                fn __type_id() -> usize {
+                    YamlFormatType::of::<Self>()
+                }
+                unsafe fn __reconstitute(ptr: *const ()) -> &'static dyn YamlFormat {
+                    YamlFormatType::cast::<Self>(ptr)
+                }
+            }
+            inventory::submit! {
+                YamlFormatType {
+                    id: #name::__type_id,
+                    reconstitute: #name::__reconstitute,
+                }
+            }
+        };
+    }
 }

--- a/yamlformat_derive/src/expand.rs
+++ b/yamlformat_derive/src/expand.rs
@@ -1,0 +1,116 @@
+use crate::ast::{Enum, Field, Input, Struct, Variant};
+use crate::attr::{Comment, Format};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Index, Member, Result};
+
+pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
+    let input = Input::from_syn(node)?;
+
+    Ok(match input {
+        Input::Struct(input) => impl_struct(input),
+        Input::Enum(input) => impl_enum(input),
+    })
+}
+
+fn impl_field_format(fields: &[Field]) -> Vec<TokenStream> {
+    fields
+        .iter()
+        .map(|f| {
+            let format = match &f.attrs.format {
+                Format::None => quote! { None },
+                Format::Block => quote! { Some(Format::Block) },
+                Format::Binary => quote! { Some(Format::Binary) },
+                Format::Decimal => quote! { Some(Format::Decimal) },
+                Format::Hex => quote! { Some(Format::Hex) },
+                Format::Octal => quote! { Some(Format::Octal) },
+            };
+            match &f.member {
+                Member::Named(id) => {
+                    let id = id.to_string();
+                    quote! { MemberId::Name(#id) => #format }
+                }
+                Member::Unnamed(Index { index: i, .. }) => {
+                    quote! { MemberId::Index(#i) => #format }
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+fn impl_field_comment(fields: &[Field]) -> Vec<TokenStream> {
+    fields
+        .iter()
+        .map(|f| {
+            let comment = match &f.attrs.comment {
+                Comment::None => quote! { None },
+                Comment::Static(s) => quote! {
+                    Some(#s.to_string())
+                },
+                Comment::Field(id) => quote! {
+                    Some(self.#id.to_string())
+                },
+                Comment::Function(id) => quote! {
+                    self.#id()
+                },
+            };
+            match &f.member {
+                Member::Named(id) => {
+                    let id = id.to_string();
+                    quote! { MemberId::Name(#id) => #comment }
+                }
+                Member::Unnamed(Index { index: i, .. }) => {
+                    quote! { MemberId::Index(#i) => #comment }
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+fn impl_struct(input: Struct) -> TokenStream {
+    let formats = impl_field_format(&input.fields);
+    let comments = impl_field_comment(&input.fields);
+    let name = &input.ident;
+    let namestr = name.to_string();
+    quote! {
+        const _: () = {
+            extern crate serde_yaml;
+            extern crate inventory;
+            use serde_yaml::yamlformat::{YamlFormat, YamlFormatType, Format, MemberId};
+
+            impl YamlFormat for #name {
+                fn format(&self, field: &MemberId) -> Option<Format> {
+                    match field {
+                        #(#formats),*,
+                        _ => None,
+                    }
+                }
+                fn comment(&self, field: &MemberId) -> Option<String> {
+                    match field {
+                        #(#comments),*,
+                        _ => None,
+                    }
+                }
+            }
+            impl #name {
+                fn __type_id() -> usize {
+                    YamlFormatType::of::<Self>()
+                }
+                unsafe fn __reconstitute(ptr: *const ()) -> &'static dyn YamlFormat {
+                    YamlFormatType::cast::<Self>(ptr)
+                }
+            }
+            inventory::submit! {
+                YamlFormatType {
+                    id: #name::__type_id,
+                    reconstitute: #name::__reconstitute,
+                }
+            }
+        };
+    }
+}
+
+fn impl_enum(input: Enum) -> TokenStream {
+    println!("{:?}", input);
+    quote! {}
+}

--- a/yamlformat_derive/src/lib.rs
+++ b/yamlformat_derive/src/lib.rs
@@ -1,0 +1,16 @@
+extern crate proc_macro;
+
+mod ast;
+mod attr;
+mod expand;
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(YamlFormat, attributes(yaml))]
+pub fn derive_yaml_format(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand::derive(&input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}


### PR DESCRIPTION
This PR represents a first attempt at allowing serde-yaml to emit comments, multi-line string blocks and alternate integer encodings in serialized output.

## Why might you want this
I have a number of tools in which I want to emit human & machine readable outputs.  Some of the outputs represent data from hardware devices (e.g. SPI eeproms) or low-level information about hardware (CPU addresses, register values).  For human readability, it is often more convenient represent these integers as hex or binary.

Furthermore, since some of my tools are diagnostic in nature, it is convenient to have comments which would either show the breakdown of register bitfields or to tell the user what a particular value _should_ be: ie: the `signature` field of a SPI eeprom's SFDP header should be the value `0x50444653` (aka `'SFDP'`).  See the samples in [`tests/test_format.rs`](https://github.com/cfrantz/serde-yaml/blob/yamlformat/tests/test_format.rs).

## The implementation
In order to accomplish this, I have some as-yet uncommitted changes to the rust-yaml library which permit emitting comments and multi-line string blocks.

Within the serde-yaml library, I've added a procedural macro which allows the user to derive `YamlFormat` on a struct and specify attributes which inform the serializer about the preferred output forms (e.g. `#[yaml(format=hex, comment="CPU Address")]`).

The generated code uses the `inventory` crate to remember the type-ids of every struct for which `YamlFormat` is derived.  During serialization, the type-id of each struct is looked up and _if_ the struct has `YamlFormat`, it is queried for preferred output forms and comments and the serializer formats the output accordingly.

## Concerns
This is my first go at this sort of thing.
- A lot of the proc macro is cribbed from looking at `thiserror` and some of your other work.
- I don't really understand the relationship between `'static` and `std::any::TypeId` (ie: why should TypeId care about 'static?) and have written my own type-id function based on [this example](https://github.com/rust-lang/rust/issues/41875#issuecomment-317292888).
- I'm not sure I've taken the best approach within the serializer.
- I think I should re-work my extensions to yaml-rust a bit: relocate all of my extensions under a single variant within the `Yaml` enum.