### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() -> Result<(), serde_yaml::Error> {
     let point = Point { x: 1.0, y: 2.0 };
 
     let s = serde_yaml::to_string(&point)?;
-    assert_eq!(s, "---\nx: 1.0\ny: 2.0");
+    assert_eq!(s, "---\nx: 1.0\ny: 2.0\n");
 
     let deserialized_point: Point = serde_yaml::from_str(&s)?;
     assert_eq!(point, deserialized_point);


### PR DESCRIPTION
Similar to https://github.com/dtolnay/serde-yaml/pull/191, fixed assertion failing in README example.