### PR TITLE
Explicitly enable indexmap/std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["yaml", "serde"]
 
 [dependencies]
 ryu = "1.0"
-indexmap = "1.5"
+indexmap = { version = "1.5.2", features = ["std"] }
 serde = "1.0.69"
 yaml-rust = "0.4.5"
 


### PR DESCRIPTION
`indexmap`'s use of `autocfg` doesn't always properly detect `std`, which is needed if you're using the default `S` hasher. The "indexmap/std" feature will explicitly force it on.

Fixes #229.