### PR TITLE
Add .flush() method to Serializer

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -48,6 +48,11 @@ where
         }
     }
 
+    /// Calls [`.flush()`](io::Write::flush) on the underlying `io::Write` object.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
     /// Unwrap the underlying `io::Write` object from the `Serializer`.
     pub fn into_inner(self) -> W {
         self.writer


### PR DESCRIPTION
Without this method, in order to flush the writer between YAML documents, the user has to call `.into_inner()` to get the underlying writer, optionally write "...\n", call `.flush()` on the writer, and then construct a new `Serializer`.