### PR TITLE
Disallow iterating Deserializers obtained from iteration

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -27,7 +27,7 @@ impl Loader {
                 rdr.read_to_end(&mut buffer).map_err(error::io)?;
                 Input2::Slice(&buffer)
             }
-            Input::Multidoc(_) => unreachable!(),
+            Input::Iterable(_) | Input::Document(_) => unreachable!(),
             Input::Fail(err) => return Err(error::shared(err)),
         };
 


### PR DESCRIPTION
The idiom for iterating over documents in a single input is:

```rust
let de = serde_yaml::Deserializer::from_str(…);
for document in de {
    let t = T::deserialize(document)?;
    …
}
```

It's confusing to assign semantics to the following however, since YAML only has one level of documents; documents cannot be nested inside of other documents.

```rust
let de = serde_yaml::Deserializer::from_str(…);
for document in de {
    for nested in document {
        let t = T::deserialize(nested)?;
    }
}
```

Previously this would do something confusing based on whether a `T` had been deserialized from `document` directly already or not. After this PR, `document` will always appear empty when iterated.