### PR TITLE
Store potentially non-utf8 for scalars

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -65,7 +65,7 @@ impl Loader {
                 YamlEvent::Alias(id) => Event::Alias(id),
                 YamlEvent::Scalar(value, style, id, tag) => {
                     loader.aliases.insert(id, loader.events.len());
-                    Event::Scalar(value, style, tag)
+                    Event::Scalar(value.into_bytes(), style, tag)
                 }
                 YamlEvent::SequenceStart(id) => {
                     loader.aliases.insert(id, loader.events.len());


### PR DESCRIPTION
The current yaml-rust backend can't produce these, but libyaml will be able to.