### PR TITLE
Make serde_yaml::value module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{to_string, to_vec, to_writer, Serializer};
+#[doc(inline)]
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};
 
 #[doc(inline)]
@@ -131,4 +132,4 @@ pub mod mapping;
 mod number;
 mod path;
 mod ser;
-mod value;
+pub mod value;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,3 +1,5 @@
+//! The Value enum, a loosely typed way of representing any valid YAML value.
+
 mod de;
 mod from;
 mod index;


### PR DESCRIPTION
This matches the similar API of `serde_json::value`.