### PR TITLE
Route variant name serialization through serialize_str

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -293,10 +293,7 @@ where
         T: ?Sized + ser::Serialize,
     {
         self.emit_mapping_start()?;
-        self.emit_scalar(Scalar {
-            value: variant,
-            style: ScalarStyle::Any,
-        })?;
+        self.serialize_str(variant)?;
         value.serialize(&mut *self)?;
         self.emit_mapping_end()
     }
@@ -339,10 +336,7 @@ where
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
         self.emit_mapping_start()?;
-        self.emit_scalar(Scalar {
-            value: variant,
-            style: ScalarStyle::Any,
-        })?;
+        self.serialize_str(variant)?;
         self.emit_sequence_start()?;
         Ok(self)
     }
@@ -365,10 +359,7 @@ where
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         self.emit_mapping_start()?;
-        self.emit_scalar(Scalar {
-            value: variant,
-            style: ScalarStyle::Any,
-        })?;
+        self.serialize_str(variant)?;
         self.emit_mapping_start()?;
         Ok(self)
     }


### PR DESCRIPTION
I am about to add some logic to detect strings that need surrounding quotes in order to roundtrip (`"true"` for example) and this change will help to only need that in one place.