### PR TITLE
Replace handwritten PartialEq with derive for Value

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -9,14 +9,13 @@ mod ser;
 use crate::{Error, Mapping};
 use serde::de::{Deserialize, DeserializeOwned, IntoDeserializer};
 use serde::Serialize;
-use std::hash::{Hash, Hasher};
 
 pub use self::index::Index;
 pub use self::ser::Serializer;
 pub use crate::number::Number;
 
 /// Represents any valid YAML value.
-#[derive(Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, PartialOrd, Hash, Debug)]
 pub enum Value {
     /// Represents a YAML null value.
     Null,
@@ -591,19 +590,6 @@ impl Value {
 }
 
 impl Eq for Value {}
-
-impl Hash for Value {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            Value::Null => 0.hash(state),
-            Value::Bool(b) => (1, b).hash(state),
-            Value::Number(i) => (2, i).hash(state),
-            Value::String(s) => (3, s).hash(state),
-            Value::Sequence(seq) => (4, seq).hash(state),
-            Value::Mapping(map) => (5, map).hash(state),
-        }
-    }
-}
 
 impl<'de> IntoDeserializer<'de, Error> for Value {
     type Deserializer = Self;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -16,7 +16,7 @@ pub use self::ser::Serializer;
 pub use crate::number::Number;
 
 /// Represents any valid YAML value.
-#[derive(Clone, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, PartialOrd, Debug)]
 pub enum Value {
     /// Represents a YAML null value.
     Null,

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,19 +1,5 @@
 use crate::Value;
 
-impl PartialEq for Value {
-    fn eq(&self, other: &Value) -> bool {
-        match (self, other) {
-            (Value::Null, Value::Null) => true,
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Number(a), Value::Number(b)) => a == b,
-            (Value::String(a), Value::String(b)) => a == b,
-            (Value::Sequence(a), Value::Sequence(b)) => a == b,
-            (Value::Mapping(a), Value::Mapping(b)) => a == b,
-            _ => false,
-        }
-    }
-}
-
 impl PartialEq<str> for Value {
     /// Compare `str` with YAML value
     ///


### PR DESCRIPTION
This impl being handwritten was obsoleted by #64. Prior to that PR it was necessary in order to handle the F64 variant specially.