### PR TITLE
Add a billion laughs mitigation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub(crate) enum ErrorImpl {
     EndOfStream,
     MoreThanOneDocument,
     RecursionLimitExceeded(libyaml::Mark),
+    RepetitionLimitExceeded,
     UnknownAnchor(libyaml::Mark),
 
     Shared(Arc<ErrorImpl>),
@@ -113,6 +114,10 @@ pub(crate) fn string_utf8(err: string::FromUtf8Error) -> Error {
 
 pub(crate) fn recursion_limit_exceeded(mark: libyaml::Mark) -> Error {
     Error(Box::new(ErrorImpl::RecursionLimitExceeded(mark)))
+}
+
+pub(crate) fn repetition_limit_exceeded() -> Error {
+    Error(Box::new(ErrorImpl::RepetitionLimitExceeded))
 }
 
 pub(crate) fn unknown_anchor(mark: libyaml::Mark) -> Error {
@@ -229,6 +234,7 @@ impl ErrorImpl {
             ErrorImpl::RecursionLimitExceeded(mark) => {
                 write!(f, "recursion limit exceeded at {}", mark)
             }
+            ErrorImpl::RepetitionLimitExceeded => f.write_str("repetition limit exceeded"),
             ErrorImpl::UnknownAnchor(mark) => write!(f, "unknown anchor at {}", mark),
             ErrorImpl::Shared(err) => err.display(f),
         }
@@ -245,6 +251,7 @@ impl ErrorImpl {
             ErrorImpl::RecursionLimitExceeded(mark) => {
                 f.debug_tuple("RecursionLimitExceeded").field(mark).finish()
             }
+            ErrorImpl::RepetitionLimitExceeded => f.debug_tuple("RepetitionLimitExceeded").finish(),
             ErrorImpl::UnknownAnchor(mark) => f.debug_tuple("UnknownAnchor").field(mark).finish(),
             ErrorImpl::Shared(err) => err.debug(f),
         }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -1,7 +1,9 @@
 use indoc::indoc;
+use serde::de::{Deserialize, SeqAccess, Visitor};
 use serde_derive::Deserialize;
 use serde_yaml::Deserializer;
-use std::fmt::Debug;
+use std::collections::BTreeMap;
+use std::fmt::{self, Debug};
 
 fn test_error<T>(yaml: &str, expected: &str)
 where
@@ -282,4 +284,54 @@ fn test_finite_recursion_arrays() {
     let yaml = "[".repeat(1_000) + &"]".repeat(1_000);
     let expected = "recursion limit exceeded at line 1 column 129";
     test_error::<S>(&yaml, expected);
+}
+
+#[cfg(not(miri))]
+#[test]
+fn test_billion_laughs() {
+    #[derive(Debug)]
+    struct X;
+
+    impl<'de> Deserialize<'de> for X {
+        fn deserialize<D>(deserializer: D) -> Result<X, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            impl<'de> Visitor<'de> for X {
+                type Value = X;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("exponential blowup")
+                }
+
+                fn visit_unit<E>(self) -> Result<X, E> {
+                    Ok(X)
+                }
+
+                fn visit_seq<S>(self, mut seq: S) -> Result<X, S::Error>
+                where
+                    S: SeqAccess<'de>,
+                {
+                    while let Some(X) = seq.next_element()? {}
+                    Ok(X)
+                }
+            }
+
+            deserializer.deserialize_any(X)
+        }
+    }
+
+    let yaml = indoc! {"
+        a: &a ~
+        b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+        c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+        d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+        e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+        f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+        g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+        h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+        i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
+    "};
+    let expected = "repetition limit exceeded";
+    test_error::<BTreeMap<String, X>>(yaml, expected);
 }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::zero_sized_map_values)]
+
 use indoc::indoc;
 use serde::de::{Deserialize, SeqAccess, Visitor};
 use serde_derive::Deserialize;


### PR DESCRIPTION
We cap the number of alias jumps to 100&times; the number of events in the input stream.

Closes #53.