### PR TITLE
Disable bytes serialization and deserialization

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1417,18 +1417,18 @@ impl<'de, 'document> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, 
         self.deserialize_str(visitor)
     }
 
-    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_any(visitor)
+        Err(error::bytes_unsupported())
     }
 
-    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_bytes(visitor)
+        Err(error::bytes_unsupported())
     }
 
     /// Parses `null` as None and any other values as `Some(...)`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ pub(crate) enum ErrorImpl {
     MoreThanOneDocument,
     RecursionLimitExceeded(libyaml::Mark),
     RepetitionLimitExceeded,
+    BytesUnsupported,
     UnknownAnchor(libyaml::Mark),
 
     Shared(Arc<ErrorImpl>),
@@ -118,6 +119,10 @@ pub(crate) fn recursion_limit_exceeded(mark: libyaml::Mark) -> Error {
 
 pub(crate) fn repetition_limit_exceeded() -> Error {
     Error(Box::new(ErrorImpl::RepetitionLimitExceeded))
+}
+
+pub(crate) fn bytes_unsupported() -> Error {
+    Error(Box::new(ErrorImpl::BytesUnsupported))
 }
 
 pub(crate) fn unknown_anchor(mark: libyaml::Mark) -> Error {
@@ -235,6 +240,9 @@ impl ErrorImpl {
                 write!(f, "recursion limit exceeded at {}", mark)
             }
             ErrorImpl::RepetitionLimitExceeded => f.write_str("repetition limit exceeded"),
+            ErrorImpl::BytesUnsupported => {
+                f.write_str("serialization and deserialization of bytes in YAML is not implemented")
+            }
             ErrorImpl::UnknownAnchor(mark) => write!(f, "unknown anchor at {}", mark),
             ErrorImpl::Shared(err) => err.display(f),
         }
@@ -252,6 +260,7 @@ impl ErrorImpl {
                 f.debug_tuple("RecursionLimitExceeded").field(mark).finish()
             }
             ErrorImpl::RepetitionLimitExceeded => f.debug_tuple("RepetitionLimitExceeded").finish(),
+            ErrorImpl::BytesUnsupported => f.debug_tuple("BytesUnsupported").finish(),
             ErrorImpl::UnknownAnchor(mark) => f.debug_tuple("UnknownAnchor").field(mark).finish(),
             ErrorImpl::Shared(err) => err.debug(f),
         }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -364,8 +364,8 @@ where
         })
     }
 
-    fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        self.collect_seq(value)
+    fn serialize_bytes(self, _value: &[u8]) -> Result<()> {
+        Err(error::bytes_unsupported())
     }
 
     fn serialize_unit(self) -> Result<()> {

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -7,9 +7,9 @@ use serde_yaml::Deserializer;
 use std::collections::BTreeMap;
 use std::fmt::{self, Debug};
 
-fn test_error<T>(yaml: &str, expected: &str)
+fn test_error<'de, T>(yaml: &'de str, expected: &str)
 where
-    T: serde::de::DeserializeOwned + Debug,
+    T: Deserialize<'de> + Debug,
 {
     let result = serde_yaml::from_str::<T>(yaml);
     assert_eq!(expected, result.unwrap_err().to_string());
@@ -96,6 +96,12 @@ fn test_ignored_unknown_anchor() {
     "};
     let expected = "unknown anchor at line 1 column 5";
     test_error::<Wrapper>(yaml, expected);
+}
+
+#[test]
+fn test_bytes() {
+    let expected = "serialization and deserialization of bytes in YAML is not implemented";
+    test_error::<&[u8]>("...", expected);
 }
 
 #[test]


### PR DESCRIPTION
I guess we'll want to implement this using YAML's binary type, per #91. Whatever it's currently doing is not right; delete for now.