### PR TITLE
Remove serde_yaml::to_vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 
 pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
 pub use crate::error::{Error, Location, Result};
-pub use crate::ser::{to_string, to_vec, to_writer, Serializer};
+pub use crate::ser::{to_string, to_writer, Serializer};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -727,19 +727,6 @@ where
     value.serialize(&mut serializer)
 }
 
-/// Serialize the given data structure as a YAML byte vector.
-///
-/// Serialization can fail if `T`'s implementation of `Serialize` decides to
-/// return an error.
-pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
-where
-    T: ?Sized + ser::Serialize,
-{
-    let mut vec = Vec::with_capacity(128);
-    to_writer(&mut vec, value)?;
-    Ok(vec)
-}
-
 /// Serialize the given data structure as a String of YAML.
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
@@ -748,6 +735,7 @@ pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: ?Sized + ser::Serialize,
 {
-    let vec = to_vec(value)?;
+    let mut vec = Vec::with_capacity(128);
+    to_writer(&mut vec, value)?;
     String::from_utf8(vec).map_err(|error| error::new(ErrorImpl::FromUtf8(error)))
 }


### PR DESCRIPTION
I don't know of this being useful. Directly use `to_writer` instead if you need bytes for I/O, or  use `to_string` + https://doc.rust-lang.org/std/string/struct.String.html#method.into_bytes if you really need the `Vec<u8>`.