### PR TITLE
Improve Debug representation of Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -179,12 +179,7 @@ impl de::Error for Error {
 
 impl ErrorImpl {
     fn location(&self) -> Option<Location> {
-        match self {
-            ErrorImpl::Message(_, Some(pos)) => Some(Location::from_mark(pos.mark)),
-            ErrorImpl::Libyaml(err) => Some(Location::from_mark(err.mark())),
-            ErrorImpl::Shared(err) => err.location(),
-            _ => None,
-        }
+        self.mark().map(Location::from_mark)
     }
 
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
@@ -201,6 +196,7 @@ impl ErrorImpl {
             ErrorImpl::Message(_, Some(Pos { mark, path: _ }))
             | ErrorImpl::RecursionLimitExceeded(mark)
             | ErrorImpl::UnknownAnchor(mark) => Some(*mark),
+            ErrorImpl::Libyaml(err) => Some(err.mark()),
             ErrorImpl::Shared(err) => err.mark(),
             _ => None,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -252,7 +252,9 @@ impl ErrorImpl {
             _ => {
                 self.message_no_mark(f)?;
                 if let Some(mark) = self.mark() {
-                    write!(f, " at {}", mark)?;
+                    if mark.line() != 0 || mark.column() != 0 {
+                        write!(f, " at {}", mark)?;
+                    }
                 }
                 Ok(())
             }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -154,7 +154,7 @@ fn test_missing_enum_tag() {
         "V": 16
         "other": 32
     "#};
-    let expected = "invalid type: map, expected a YAML tag starting with '!' at position 0";
+    let expected = "invalid type: map, expected a YAML tag starting with '!'";
     test_error::<E>(yaml, expected);
 }
 
@@ -245,7 +245,7 @@ fn test_struct_from_sequence() {
     let yaml = indoc! {"
         [0, 0]
     "};
-    let expected = "invalid type: sequence, expected struct Struct at position 0";
+    let expected = "invalid type: sequence, expected struct Struct";
     test_error::<Struct>(yaml, expected);
 }
 
@@ -332,7 +332,7 @@ fn test_infinite_recursion_objects() {
     }
 
     let yaml = "&a {'x': *a}";
-    let expected = "recursion limit exceeded at position 0";
+    let expected = "recursion limit exceeded";
     test_error::<S>(yaml, expected);
 }
 
@@ -343,7 +343,7 @@ fn test_infinite_recursion_arrays() {
     struct S(usize, Option<Box<S>>);
 
     let yaml = "&a [0, *a]";
-    let expected = "recursion limit exceeded at position 0";
+    let expected = "recursion limit exceeded";
     test_error::<S>(yaml, expected);
 }
 
@@ -354,7 +354,7 @@ fn test_infinite_recursion_newtype() {
     struct S(Option<Box<S>>);
 
     let yaml = "&a [*a]";
-    let expected = "recursion limit exceeded at position 0";
+    let expected = "recursion limit exceeded";
     test_error::<S>(yaml, expected);
 }
 


### PR DESCRIPTION
This matches the approach used for serde_json's errors, and is a good fit for the formatting that appears when `.unwrap()` is used.

**Before:**

```rust
UnknownAnchor(
    Mark {
        line: 1,
        column: 5,
    },
)
```

**After:**

```rust
Error("unknown anchor", line: 1, column: 5)
```