### PR TITLE
Implement deserialize_struct via deserialize_map

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -432,10 +432,7 @@ impl<'de> Deserializer<'de> for Value {
     where
         V: Visitor<'de>,
     {
-        match self.untag() {
-            Value::Mapping(v) => visit_mapping(v, visitor),
-            other => Err(other.invalid_type(&visitor)),
-        }
+        self.deserialize_map(visitor)
     }
 
     fn deserialize_enum<V>(
@@ -950,10 +947,7 @@ impl<'de> Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match self.untag_ref() {
-            Value::Mapping(v) => visit_mapping_ref(v, visitor),
-            other => Err(other.invalid_type(&visitor)),
-        }
+        self.deserialize_map(visitor)
     }
 
     fn deserialize_enum<V>(


### PR DESCRIPTION
There should be no observable difference in behavior. Having a separate deserialize_struct implementation was obsoleted by 395a0eb1260a8335c1d3712975d2911cddfcd643.