### PR TITLE
Set width=-1 on libyaml emitter

### DIFF
--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -70,6 +70,7 @@ impl<'a> Emitter<'a> {
                 panic!("malloc error: {}", libyaml::Error::emit_error(emitter));
             }
             sys::yaml_emitter_set_unicode(emitter, true);
+            sys::yaml_emitter_set_width(emitter, -1);
             addr_of_mut!((*owned.ptr).write).write(write);
             addr_of_mut!((*owned.ptr).write_error).write(None);
             sys::yaml_emitter_set_output(emitter, write_handler, owned.ptr.cast());

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -11,6 +11,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_yaml::{Mapping, Number, Value};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::iter;
 
 fn test_serde<T>(thing: &T, yaml: &str)
 where
@@ -524,6 +525,26 @@ fn test_mapping() {
         substructure:
           a: foo
           b: bar
+    "};
+
+    test_serde(&thing, yaml);
+}
+
+#[test]
+fn test_long_string() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Data {
+        pub string: String,
+    }
+
+    let thing = Data {
+        string: iter::repeat(["word", " "]).flatten().take(69).collect(),
+    };
+
+    let yaml = indoc! {"
+        string: word word word word word word word word word word word word word word word
+          word word word word word word word word word word word word word word word word
+          word word word word
     "};
 
     test_serde(&thing, yaml);

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -542,9 +542,7 @@ fn test_long_string() {
     };
 
     let yaml = indoc! {"
-        string: word word word word word word word word word word word word word word word
-          word word word word word word word word word word word word word word word word
-          word word word word
+        string: word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word word
     "};
 
     test_serde(&thing, yaml);


### PR DESCRIPTION
For strings that already contain newlines, serde_yaml will preserve them (since #270). For strings that do not already contain newlines I don't think serde_yaml should add newlines to them. Closes #321.