### PR TITLE
Allow direct inspection of a Tag.

### DIFF
--- a/src/value/tagged.rs
+++ b/src/value/tagged.rs
@@ -83,6 +83,18 @@ impl Tag {
             string: string.into(),
         }
     }
+
+    /// Get the local tag as a [`str`] with the leading `!` stripped.
+    ///
+    /// ```
+    /// use serde_yaml::value::Tag;
+    ///
+    /// assert_eq!(Tag::new("Thing").as_str_stripped(), "Thing");
+    /// assert_eq!(Tag::new("!Thing").as_str_stripped(), "Thing");
+    /// ```
+    pub fn as_str_stripped(&self) -> &str {
+        nobang(&self.string)
+    }
 }
 
 impl Value {


### PR DESCRIPTION
This PR makes it possible to directly inspect a tag as a string slice.

For my use case, I want to do some more advanced inspection than only testing for equality.

To avoid surprising behavior with the potential presence of an exclamation mark, the function is called `as_str_stripped()` and documents that it strips the leading exclamation mark if it is present.