### PR TITLE
feat: add Value.merge to merge two different yaml files

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,7 @@ pub(crate) enum ErrorImpl {
     TaggedInMerge,
     ScalarInMergeElement,
     SequenceInMergeElement,
+    InvalidMergeOperation,
 
     Shared(Arc<ErrorImpl>),
 }
@@ -236,6 +237,9 @@ impl ErrorImpl {
             }
             ErrorImpl::SequenceInMergeElement => {
                 f.write_str("expected a mapping for merging, but found sequence")
+            }
+            ErrorImpl::InvalidMergeOperation => {
+                f.write_str("merging is only available between two mappings or two sequences")
             }
             ErrorImpl::Shared(_) => unreachable!(),
         }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -185,6 +185,26 @@ impl Mapping {
             iter: self.map.into_values(),
         }
     }
+
+    /// Merges another mapping into the current instance.
+    pub fn merge_with(&mut self, other: Mapping) {
+        other.into_iter().for_each(|(k, v)| {
+            match (self.get_mut(&k), v) {
+                (None, other_v) => {
+                    self.insert(k, other_v);
+                }
+                (Some(Value::Mapping(v)), Value::Mapping(other_v)) => {
+                    v.merge_with(other_v);
+                }
+                (Some(Value::Sequence(v)), Value::Sequence(other_v)) => {
+                    v.extend(other_v);
+                }
+                (_, other_v) => {
+                    self.insert(k, other_v);
+                }
+            };
+        });
+    }
 }
 
 /// A type that can be used to index into a `serde_yaml::Mapping`. See the


### PR DESCRIPTION
This PR adds a `(&mut Value).merge(Value)` to merge two YAMLs together.
The method has a documentation test as an example.

A bit unsure on the preferred design of the solution; based on the other methods in the `impl` block, I've used `&mut`. However I feel like a `merge(self, other: Value) -> Value` might be a better option.

Thoughts?
