### PR TITLE
Demonstrate issue with deserializing documents starting with a Byte Order Mark (BOM)

### DIFF
--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -360,6 +360,10 @@ fn test_byte_order_mark() {
     let expected = vec![0];
     test_de_handles_bom(yaml, &expected);
 
+    let yaml = "- 0\n- 1\n";
+    let expected = vec![0, 1];
+    test_de_handles_bom(yaml, &expected);
+
     #[derive(Deserialize, PartialEq, Debug)]
     struct TestStruct {
         name: String,


### PR DESCRIPTION
This PR purposely creates failing tests to demonstrate an issue, and therefore is not yet eligible for merging.

However, my hope is that this can act as the starting point for a conversation on how to diagnose & fix the issue discussed in #224.

Somehow, documents starting with a BOM and involving newlines seem to parse incorrectly. It is almost as though the newlines are erroneously considered end of document markers?