### PR TITLE
Fix message duplication between error Display and source()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -184,8 +184,8 @@ impl ErrorImpl {
 
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            ErrorImpl::Io(err) => Some(err),
-            ErrorImpl::FromUtf8(err) => Some(err),
+            ErrorImpl::Io(err) => err.source(),
+            ErrorImpl::FromUtf8(err) => err.source(),
             ErrorImpl::Shared(err) => err.source(),
             _ => None,
         }


### PR DESCRIPTION
Fixes #359.

The same code in the issue now produces:

```console
Error: bad read

Caused by:
    timed out waiting on channel
```