### PR TITLE
Use quoted style for strings consisting of digits with leading zero

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -339,8 +339,12 @@ where
                 Ok(ScalarStyle::SingleQuoted)
             }
 
-            fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E> {
-                Ok(ScalarStyle::Any)
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(if crate::de::digits_but_not_number(v) {
+                    ScalarStyle::SingleQuoted
+                } else {
+                    ScalarStyle::Any
+                })
             }
 
             fn visit_unit<E>(self) -> Result<Self::Value, E> {

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -311,7 +311,7 @@ fn test_strings_needing_quote() {
         boolean: 'true'
         integer: '1'
         void: 'null'
-        leading_zeros: 007
+        leading_zeros: '007'
     "#};
     test_serde(&thing, yaml);
 }

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -299,16 +299,19 @@ fn test_strings_needing_quote() {
         boolean: String,
         integer: String,
         void: String,
+        leading_zeros: String,
     }
     let thing = Struct {
         boolean: "true".to_owned(),
         integer: "1".to_owned(),
         void: "null".to_owned(),
+        leading_zeros: "007".to_owned(),
     };
     let yaml = indoc! {r#"
         boolean: 'true'
         integer: '1'
         void: 'null'
+        leading_zeros: 007
     "#};
     test_serde(&thing, yaml);
 }


### PR DESCRIPTION
Closes #347.