### PR TITLE
New API to get anchors and aliases from a document

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -8,6 +8,7 @@ use serde::de::value::StrDeserializer;
 use serde::de::{
     self, Deserialize, DeserializeOwned, DeserializeSeed, Expected, IgnoredAny, Unexpected, Visitor,
 };
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io;
 use std::mem;
@@ -68,6 +69,51 @@ pub(crate) enum Progress<'de> {
     Fail(Arc<ErrorImpl>),
 }
 
+/// A structure that describes anchors and aliases in a YAML document.
+/// The anchor name, prefixed in the YAML document with "&", is represented
+/// without the prefix in `anchor_name`.
+/// The `anchor_path` is a string that denotes the path to the anchor in the YAML
+/// document. Each key that form the path is separated from one another by "/".
+/// The `aliases` vector contains the path to each reference to the anchor in
+/// the YAML document.
+///
+/// # Examples
+///
+/// The following YAML document:
+/// ```
+/// a:
+///   enum: &io
+///     INPUT: 0
+///     OUTPUT: 1
+/// b:
+///   enum: *io
+/// c:
+///   enum: *io
+/// ```
+///
+/// Is represented by the following `DocumentAnchor`:
+/// ```
+/// DocumentAnchor {
+///   anchor_name: "io",
+///   anchor_path: "/a/enum",
+///   aliases: ["/b/enum", "/c/enum"],
+/// }
+/// ```
+#[derive(Debug)]
+pub struct DocumentAnchor {
+    /// The name of the anchor, without the "&" prefix.
+    pub anchor_name: String,
+
+    /// The path to the anchor in the YAML document, with keys separated by "/".
+    /// A "/" at the beginning of the path denotes the root of the YAML document.
+    pub anchor_path: String,
+
+    /// The path to each alias that references the anchor in the YAML document.
+    /// Each key that form the alias path is separated by "/".
+    /// A "/" at the beginning of the path denotes the root of the YAML document.
+    pub aliases: Vec<String>,
+}
+
 impl<'de> Deserializer<'de> {
     /// Creates a YAML deserializer from a `&str`.
     pub fn from_str(s: &'de str) -> Self {
@@ -92,6 +138,68 @@ impl<'de> Deserializer<'de> {
     {
         let progress = Progress::Read(Box::new(rdr));
         Deserializer { progress }
+    }
+
+    /// Gets a vector of anchors, aliases, and where they occur in the YAML document.
+    pub fn anchors(&self) -> Option<Vec<DocumentAnchor>> {
+        let document = match &self.progress {
+            Progress::Document(doc) => doc,
+            _ => return None,
+        };
+
+        let mut aliases = BTreeMap::<usize, Vec<usize>>::new();
+        for (i, event) in document.events.iter().enumerate() {
+            match event {
+                (Event::Alias(id), _) => aliases.entry(*id).or_default().push(i),
+                _ => {}
+            }
+        }
+
+        let mut anchors = Vec::new();
+        for (alias_id, document_index) in &document.aliases {
+            let anchor_name = document.anchors.get(alias_id).unwrap();
+            let anchor_path = self.event_path(*document_index, document);
+            let mut anchors_aliases = Vec::new();
+            for alias_index in aliases.get(alias_id).unwrap_or(&Vec::new()).iter() {
+                anchors_aliases.push(self.event_path(*alias_index, document));
+            }
+
+            anchors.push(DocumentAnchor {
+                anchor_name: anchor_name.clone(),
+                anchor_path: anchor_path.clone(),
+                aliases: anchors_aliases,
+            });
+        }
+
+        Some(anchors)
+    }
+
+    fn event_path(&self, event_index: usize, document: &Document<'_>) -> String {
+        let mut mapping_end = 0u32;
+        let mut process_scalar = true;
+        let mut path = Vec::new();
+
+        for i in (0..=event_index).rev() {
+            let event = &document.events[i];
+            match &event.0 {
+                Event::MappingEnd => mapping_end += 1,
+                Event::MappingStart(_) => {
+                    if mapping_end > 0 {
+                        mapping_end -= 1
+                    } else {
+                        process_scalar = true;
+                    }
+                }
+                Event::Scalar(scalar) => {
+                    if process_scalar {
+                        path.insert(0, String::from_utf8_lossy(&scalar.value).to_string());
+                        process_scalar = false;
+                    }
+                }
+                _ => {}
+            }
+        }
+        format!("/{}", path.join("/"))
     }
 
     fn de<T>(

--- a/src/de.rs
+++ b/src/de.rs
@@ -80,7 +80,7 @@ pub(crate) enum Progress<'de> {
 /// # Examples
 ///
 /// The following YAML document:
-/// ```
+/// ```yaml
 /// a:
 ///   enum: &io
 ///     INPUT: 0
@@ -92,7 +92,7 @@ pub(crate) enum Progress<'de> {
 /// ```
 ///
 /// Is represented by the following `DocumentAnchor`:
-/// ```
+/// ```json
 /// DocumentAnchor {
 ///   anchor_name: "io",
 ///   anchor_path: "/a/enum",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
     clippy::must_use_candidate,
 )]
 
-pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
+pub use crate::de::{from_reader, from_slice, from_str, Deserializer, DocumentAnchor};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{to_string, to_writer, Serializer};
 #[doc(inline)]


### PR DESCRIPTION
When deserializing a YAML document, the location and names of anchors and aliases is not preserved. That information is useful, though, as users may want to deduplicate references to the same mapping.

This commit introduces an API that exposes such mappings by parsing the metadata in `struct Document`. The new API has been added to `struct Deserializer` and provides the following signature:

   `pub fn anchors(&self) -> Option<Vec<DocumentAnchor>>`

As an example, given the following YAML document:
```
a:
    enum: &io
        INPUT: 0
        OUTPUT: 1
b:
    enum: *io
c:
    enum: *io
```

this API returns:
```
Some([DocumentAnchor {
    anchor_name: "io",
    anchor_path: "/a/enum",
    aliases: ["/b/enum", "/c/enum"],
}])