### PR TITLE
Ensure that .nan deserialization produces positive NaN

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1079,7 +1079,7 @@ pub(crate) fn parse_f64(scalar: &str) -> Option<f64> {
         return Some(f64::NEG_INFINITY);
     }
     if let ".nan" | ".NaN" | ".NAN" = scalar {
-        return Some(f64::NAN);
+        return Some(f64::NAN.copysign(1.0));
     }
     if let Ok(float) = unpositive.parse::<f64>() {
         if float.is_finite() {

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -690,6 +690,7 @@ fn test_parse_number() {
 
     let n = ".nan".parse::<Number>().unwrap();
     assert_eq!(n, Number::from(f64::NAN));
+    assert!(n.as_f64().unwrap().is_sign_positive());
 
     let n = ".inf".parse::<Number>().unwrap();
     assert_eq!(n, Number::from(f64::INFINITY));

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -20,7 +20,7 @@ fn test_nan() {
     assert!(neg_fake_nan.is_string());
 
     let significand_mask = 0xF_FFFF_FFFF_FFFF;
-    let bits = (f64::NAN.to_bits() ^ significand_mask) | 1;
+    let bits = (f64::NAN.copysign(1.0).to_bits() ^ significand_mask) | 1;
     let different_pos_nan = Value::Number(Number::from(f64::from_bits(bits)));
     assert_eq!(pos_nan, different_pos_nan);
 }


### PR DESCRIPTION
I learned in https://github.com/rust-lang/miri/issues/3139 that the sign of f64::NAN is not specified.