### PR TITLE
Add test of NaN sign when deserializing to primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 indexmap = "2"
 itoa = "1.0"
 ryu = "1.0"
-serde = "1.0.139"
+serde = "1.0.190"
 unsafe-libyaml = "0.2.7"
 
 [dev-dependencies]

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -451,6 +451,13 @@ fn test_numbers() {
 }
 
 #[test]
+fn test_nan() {
+    // There is no negative NaN in YAML.
+    assert!(serde_yaml::from_str::<f32>(".nan").unwrap().is_sign_positive());
+    assert!(serde_yaml::from_str::<f64>(".nan").unwrap().is_sign_positive());
+}
+
+#[test]
 fn test_stateful() {
     struct Seed(i64);
 


### PR DESCRIPTION
#392 covered the case of deserializing to `serde_yaml::Number` only.

For primitives, https://github.com/serde-rs/serde/pull/2637 is necessary.