### PR TITLE
Deterministically destroy sign of NaN when converted to Number

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -529,7 +529,8 @@ impl From<f32> for Number {
 impl From<f64> for Number {
     fn from(mut f: f64) -> Self {
         if f.is_nan() {
-            f = f.copysign(1.0);
+            // Destroy NaN sign, signaling, and payload. YAML only has one NaN.
+            f = f64::NAN.copysign(1.0);
         }
         Number { n: N::Float(f) }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -522,14 +522,15 @@ from_unsigned!(u8 u16 u32 u64 usize);
 
 impl From<f32> for Number {
     fn from(f: f32) -> Self {
-        Number {
-            n: N::Float(f as f64),
-        }
+        Number::from(f as f64)
     }
 }
 
 impl From<f64> for Number {
-    fn from(f: f64) -> Self {
+    fn from(mut f: f64) -> Self {
+        if f.is_nan() {
+            f = f.copysign(1.0);
+        }
         Number { n: N::Float(f) }
     }
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -517,22 +517,22 @@ macro_rules! from_unsigned {
     };
 }
 
-macro_rules! from_float {
-    ($($float_ty:ident)*) => {
-        $(
-            impl From<$float_ty> for Number {
-                #[inline]
-                fn from(f: $float_ty) -> Self {
-                    Number { n: N::Float(f as f64) }
-                }
-            }
-        )*
+from_signed!(i8 i16 i32 i64 isize);
+from_unsigned!(u8 u16 u32 u64 usize);
+
+impl From<f32> for Number {
+    fn from(f: f32) -> Self {
+        Number {
+            n: N::Float(f as f64),
+        }
     }
 }
 
-from_signed!(i8 i16 i32 i64 isize);
-from_unsigned!(u8 u16 u32 u64 usize);
-from_float!(f32 f64);
+impl From<f64> for Number {
+    fn from(f: f64) -> Self {
+        Number { n: N::Float(f) }
+    }
+}
 
 // This is fine, because we don't _really_ implement hash for floats
 // all other hash functions should work as expected


### PR DESCRIPTION
Previously the `f32 as f64` would produce a nondeterministic sign, as I found out in https://github.com/rust-lang/miri/issues/3139. This would then get leaked by `as_f64()` or by serialization of the `Number`. It doesn't make a difference when serializing to YAML, but we support serializing `serde_yaml::Number` to TOML and other formats, where it does.

YAML only has one NaN, so even negative NaNs serialize to `.nan` in YAML. It seems fine to discard the original sign in `serde_yaml::Number` too.