### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/serde_yaml/0.9.28")]
-#![deny(missing_docs)]
+#![deny(missing_docs, unsafe_op_in_unsafe_fn)]
 // Suppressed clippy_pedantic lints
 #![allow(
     // buggy

--- a/src/libyaml/emitter.rs
+++ b/src/libyaml/emitter.rs
@@ -197,13 +197,14 @@ impl<'a> Emitter<'a> {
 
 unsafe fn write_handler(data: *mut c_void, buffer: *mut u8, size: u64) -> i32 {
     let data = data.cast::<EmitterPinned>();
-    match io::Write::write_all(
-        &mut *(*data).write,
-        slice::from_raw_parts(buffer, size as usize),
-    ) {
+    match io::Write::write_all(unsafe { &mut *(*data).write }, unsafe {
+        slice::from_raw_parts(buffer, size as usize)
+    }) {
         Ok(()) => 1,
         Err(err) => {
-            (*data).write_error = Some(err);
+            unsafe {
+                (*data).write_error = Some(err);
+            }
             0
         }
     }

--- a/src/libyaml/error.rs
+++ b/src/libyaml/error.rs
@@ -18,41 +18,41 @@ pub(crate) struct Error {
 impl Error {
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
         Error {
-            kind: (*parser).error,
-            problem: match NonNull::new((*parser).problem as *mut _) {
-                Some(problem) => CStr::from_ptr(problem),
+            kind: unsafe { (*parser).error },
+            problem: match NonNull::new(unsafe { (*parser).problem as *mut _ }) {
+                Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => CStr::from_bytes_with_nul(b"libyaml parser failed but there is no error\0"),
             },
-            problem_offset: (*parser).problem_offset,
+            problem_offset: unsafe { (*parser).problem_offset },
             problem_mark: Mark {
-                sys: (*parser).problem_mark,
+                sys: unsafe { (*parser).problem_mark },
             },
-            context: match NonNull::new((*parser).context as *mut _) {
-                Some(context) => Some(CStr::from_ptr(context)),
+            context: match NonNull::new(unsafe { (*parser).context as *mut _ }) {
+                Some(context) => Some(unsafe { CStr::from_ptr(context) }),
                 None => None,
             },
             context_mark: Mark {
-                sys: (*parser).context_mark,
+                sys: unsafe { (*parser).context_mark },
             },
         }
     }
 
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
         Error {
-            kind: (*emitter).error,
-            problem: match NonNull::new((*emitter).problem as *mut _) {
-                Some(problem) => CStr::from_ptr(problem),
+            kind: unsafe { (*emitter).error },
+            problem: match NonNull::new(unsafe { (*emitter).problem as *mut _ }) {
+                Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => {
                     CStr::from_bytes_with_nul(b"libyaml emitter failed but there is no error\0")
                 }
             },
             problem_offset: 0,
             problem_mark: Mark {
-                sys: MaybeUninit::<sys::yaml_mark_t>::zeroed().assume_init(),
+                sys: unsafe { MaybeUninit::<sys::yaml_mark_t>::zeroed().assume_init() },
             },
             context: None,
             context_mark: Mark {
-                sys: MaybeUninit::<sys::yaml_mark_t>::zeroed().assume_init(),
+                sys: unsafe { MaybeUninit::<sys::yaml_mark_t>::zeroed().assume_init() },
             },
         }
     }


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.