### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
     clippy::match_same_arms,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
-    clippy::option_if_let_else,
     clippy::redundant_else,
     clippy::single_match_else,
     // code is acceptable


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.