### PR TITLE
Quote YAML 1.1 bools during serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ fn main() -> Result<(), serde_yaml::Error> {
     let point = Point { x: 1.0, y: 2.0 };
 
     let yaml = serde_yaml::to_string(&point)?;
-    assert_eq!(yaml, "x: 1.0\ny: 2.0\n");
+    assert_eq!(yaml, "x: 1.0\n'y': 2.0\n");
 
     let deserialized_point: Point = serde_yaml::from_str(&yaml)?;
     assert_eq!(point, deserialized_point);
@@ -100,7 +100,7 @@ fn main() -> Result<(), serde_yaml::Error> {
     let yaml = "
         - !Newtype 1
         - !Tuple [0, 0, 0]
-        - !Struct {x: 1.0, y: 2.0}
+        - !Struct {x: 1.0, 'y': 2.0}
     ";
     let values: Vec<Enum> = serde_yaml::from_str(yaml).unwrap();
     assert_eq!(values[0], Enum::Newtype(1));
@@ -115,7 +115,7 @@ fn main() -> Result<(), serde_yaml::Error> {
           - 0
         - !Struct
           x: 1.0
-          y: 2.0
+          'y': 2.0
     ";
     let values: Vec<Enum> = serde_yaml::from_str(yaml).unwrap();
     assert_eq!(values[0], Enum::Tuple(0, 0, 0));

--- a/src/de.rs
+++ b/src/de.rs
@@ -931,8 +931,8 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
+        "true" | "True" | "TRUE" | "on" | "ON" | "yes" | "YES" => Some(true),
+        "false" | "False" | "FALSE" | "off" | "OFF" | "no" | "NO" => Some(false),
         _ => None,
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -931,8 +931,8 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" | "on" | "ON" | "yes" | "YES" => Some(true),
-        "false" | "False" | "FALSE" | "off" | "OFF" | "no" | "NO" => Some(false),
+        "true" | "True" | "TRUE" => Some(true),
+        "false" | "False" | "FALSE" => Some(false),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //!     // Serialize it to a YAML string.
 //!     let yaml = serde_yaml::to_string(&map)?;
-//!     assert_eq!(yaml, "x: 1.0\ny: 2.0\n");
+//!     assert_eq!(yaml, "x: 1.0\n'y': 2.0\n");
 //!
 //!     // Deserialize it back to a Rust type.
 //!     let deserialized_map: BTreeMap<String, f64> = serde_yaml::from_str(&yaml)?;
@@ -55,7 +55,7 @@
 //!     let point = Point { x: 1.0, y: 2.0 };
 //!
 //!     let yaml = serde_yaml::to_string(&point)?;
-//!     assert_eq!(yaml, "x: 1.0\ny: 2.0\n");
+//!     assert_eq!(yaml, "x: 1.0\n'y': 2.0\n");
 //!
 //!     let deserialized_point: Point = serde_yaml::from_str(&yaml)?;
 //!     assert_eq!(point, deserialized_point);
@@ -96,7 +96,7 @@
 //!           - 0
 //!         - !Struct
 //!           x: 1.0
-//!           y: 2.0
+//!           'y': 2.0
 //!     ";
 //!     let values: Vec<Enum> = serde_yaml::from_str(yaml).unwrap();
 //!     assert_eq!(values[0], Enum::Tuple(0, 0, 0));

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -353,8 +353,11 @@ where
         }
 
         let style = match value {
-            // Backwards compatibility with pre-YAML 1.2.2 spec for boolean keywords.
-            "on" | "ON" | "yes" | "YES" | "no" | "NO" | "off" | "OFF" => ScalarStyle::SingleQuoted,
+            // Backwards compatibility with old YAML boolean scalars.
+            // See https://yaml.org/type/bool.html
+            "y" | "Y" | "yes" | "Yes" | "YES" | "n" | "N" | "no" | "No" | "NO" | "true"
+            | "True" | "TRUE" | "false" | "False" | "FALSE" | "on" | "On" | "ON" | "off"
+            | "Off" | "OFF" => ScalarStyle::SingleQuoted,
             _ if value.contains('\n') => ScalarStyle::Literal,
             _ => {
                 let result = crate::de::visit_untagged_scalar(

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -209,10 +209,10 @@ fn test_enum_representations() {
         - !Tuple
           - 0
           - 0
-        - !Struct {x: 0, y: 0}
+        - !Struct {x: 0, 'y': 0}
         - !Struct
           x: 0
-          y: 0
+          'y': 0
         - !String '...'
         - !String ...
         - !Number 0
@@ -390,7 +390,7 @@ fn test_bomb() {
         v: &v [*u,*u,*u,*u,*u,*u,*u,*u,*u]
         w: &w [*v,*v,*v,*v,*v,*v,*v,*v,*v]
         x: &x [*w,*w,*w,*w,*w,*w,*w,*w,*w]
-        y: &y [*x,*x,*x,*x,*x,*x,*x,*x,*x]
+        'y': &y [*x,*x,*x,*x,*x,*x,*x,*x,*x]
         z: &z [*y,*y,*y,*y,*y,*y,*y,*y,*y]
         expected: string
     "};

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -271,6 +271,26 @@ fn test_string_escapes() {
 }
 
 #[test]
+fn test_can_deser_bool_keywords_and_quote_as_strings() {
+    for (thing, yaml) in vec![
+        (true, "on"),
+        (false, "off"),
+        (true, "yes"),
+        (false, "no"),
+        (true, "true"),
+        (false, "false"),
+    ] {
+        // Serializing them as strings renders them with quotes.
+        let formatted: String = serde_yaml::to_string(yaml).unwrap();
+        assert_eq!(formatted, format!("'{}'\n", yaml));
+
+        // YAML boolean keywords can be deserialized into bool.
+        let value: bool = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(thing, value);
+    }
+}
+
+#[test]
 fn test_multiline_string() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Struct {

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -271,17 +271,42 @@ fn test_string_escapes() {
 }
 
 #[test]
-fn test_bool_keywords_are_serialized_for_backwards_compatibility() {
-    for yaml in vec!["on", "off", "yes", "no"] {
-        // Serializing YAML bool keywords to strings adds quotes for compatibility with
-        // older YAML specs.
-        let formatted: String = serde_yaml::to_string(yaml).unwrap();
-        assert_eq!(formatted, format!("'{}'\n", yaml));
+fn test_boolish_serialization() {
+    let thing = vec![
+        Value::String("on".to_owned()),
+        Value::String("ON".to_owned()),
+        Value::String("off".to_owned()),
+        Value::String("OFF".to_owned()),
+        Value::String("yes".to_owned()),
+        Value::String("YES".to_owned()),
+        Value::String("no".to_owned()),
+        Value::String("NO".to_owned()),
+        Value::String("true".to_owned()),
+        Value::String("TRUE".to_owned()),
+        Value::String("false".to_owned()),
+        Value::String("FALSE".to_owned()),
+        Value::Bool(true),
+        Value::Bool(false),
+    ];
 
-        // Old YAML boolean keywords can NOT be deserialized into bool.
-        let value: Result<bool, _> = serde_yaml::from_str(yaml);
-        assert!(value.is_err());
-    }
+    let yaml = indoc! {"
+        - 'on'
+        - 'ON'
+        - 'off'
+        - 'OFF'
+        - 'yes'
+        - 'YES'
+        - 'no'
+        - 'NO'
+        - 'true'
+        - 'TRUE'
+        - 'false'
+        - 'FALSE'
+        - true
+        - false
+    "};
+
+    test_serde(&thing, yaml);
 }
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -280,7 +280,7 @@ fn test_can_deser_bool_keywords_and_quote_as_strings() {
         (true, "true"),
         (false, "false"),
     ] {
-        // Serializing them as strings renders them with quotes.
+        // Serializing YAML bool keywords to strings adds quotes.
         let formatted: String = serde_yaml::to_string(yaml).unwrap();
         assert_eq!(formatted, format!("'{}'\n", yaml));
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -271,22 +271,16 @@ fn test_string_escapes() {
 }
 
 #[test]
-fn test_can_deser_bool_keywords_and_quote_as_strings() {
-    for (thing, yaml) in vec![
-        (true, "on"),
-        (false, "off"),
-        (true, "yes"),
-        (false, "no"),
-        (true, "true"),
-        (false, "false"),
-    ] {
-        // Serializing YAML bool keywords to strings adds quotes.
+fn test_bool_keywords_are_serialized_for_backwards_compatibility() {
+    for yaml in vec!["on", "off", "yes", "no"] {
+        // Serializing YAML bool keywords to strings adds quotes for compatibility with
+        // older YAML specs.
         let formatted: String = serde_yaml::to_string(yaml).unwrap();
         assert_eq!(formatted, format!("'{}'\n", yaml));
 
-        // YAML boolean keywords can be deserialized into bool.
-        let value: bool = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(thing, value);
+        // Old YAML boolean keywords can NOT be deserialized into bool.
+        let value: Result<bool, _> = serde_yaml::from_str(yaml);
+        assert!(value.is_err());
     }
 }
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -195,7 +195,7 @@ fn test_map() {
     thing.insert("y".to_owned(), 2);
     let yaml = indoc! {"
         x: 1
-        y: 2
+        'y': 2
     "};
     test_serde(&thing, yaml);
 }
@@ -238,7 +238,7 @@ fn test_basic_struct() {
     };
     let yaml = indoc! {r#"
         x: -4
-        y: "hi\tquoted"
+        'y': "hi\tquoted"
         z: true
     "#};
     test_serde(&thing, yaml);
@@ -272,36 +272,57 @@ fn test_string_escapes() {
 
 #[test]
 fn test_boolish_serialization() {
+    // See https://yaml.org/type/bool.html
     let thing = vec![
-        Value::String("on".to_owned()),
-        Value::String("ON".to_owned()),
-        Value::String("off".to_owned()),
-        Value::String("OFF".to_owned()),
+        Value::String("y".to_owned()),
+        Value::String("Y".to_owned()),
         Value::String("yes".to_owned()),
+        Value::String("Yes".to_owned()),
         Value::String("YES".to_owned()),
+        Value::String("n".to_owned()),
+        Value::String("N".to_owned()),
         Value::String("no".to_owned()),
+        Value::String("No".to_owned()),
         Value::String("NO".to_owned()),
         Value::String("true".to_owned()),
+        Value::String("True".to_owned()),
         Value::String("TRUE".to_owned()),
         Value::String("false".to_owned()),
+        Value::String("False".to_owned()),
         Value::String("FALSE".to_owned()),
+        Value::String("on".to_owned()),
+        Value::String("On".to_owned()),
+        Value::String("ON".to_owned()),
+        Value::String("off".to_owned()),
+        Value::String("Off".to_owned()),
+        Value::String("OFF".to_owned()),
         Value::Bool(true),
         Value::Bool(false),
     ];
 
     let yaml = indoc! {"
-        - 'on'
-        - 'ON'
-        - 'off'
-        - 'OFF'
+        - 'y'
+        - 'Y'
         - 'yes'
+        - 'Yes'
         - 'YES'
+        - 'n'
+        - 'N'
         - 'no'
+        - 'No'
         - 'NO'
         - 'true'
+        - 'True'
         - 'TRUE'
         - 'false'
+        - 'False'
         - 'FALSE'
+        - 'on'
+        - 'On'
+        - 'ON'
+        - 'off'
+        - 'Off'
+        - 'OFF'
         - true
         - false
     "};

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -63,8 +63,8 @@ fn test_merge() {
     // From https://yaml.org/type/merge.html.
     let yaml = indoc! {"
         ---
-        - &CENTER { x: 1, y: 2 }
-        - &LEFT { x: 0, y: 2 }
+        - &CENTER { x: 1, 'y': 2 }
+        - &LEFT { x: 0, 'y': 2 }
         - &BIG { r: 10 }
         - &SMALL { r: 1 }
 
@@ -72,7 +72,7 @@ fn test_merge() {
 
         - # Explicit keys
           x: 1
-          y: 2
+          'y': 2
           r: 10
           label: center/big
 


### PR DESCRIPTION
Closes #319

This PR handles pre-YAML 1.2 bool keywords (`on`, `off`, `yes`, `no`, etc.) during serialization to add single quotes which adds backwards compatibility when the serialized YAML is later loaded by a YAML parser for an older spec.

1.1 Reference: https://yaml.org/type/bool.html

__Notable changes__

* Examples/tests often have a field called `y` which is now serialized with quotes as well (e.g. `'y': 0`). I think this is desirable because some YAML implementations can interpret the field as a regular YAML value (and you end up with a boolean key), however I have yet to find that in the YAML spec.

<details><summary>Previous content</summary>

This PR modifies `crate::de::parse_bool()` to treat `on/ON/yes/YES/off/OFF/no/NO` as bool as per the YAML 1.1 spec. The same change also causes string values with these values to be quoted, which fixes #319.

I couldn't find whether `serde-yaml` aims to be compatible with a particular YAML spec version; the fact that it did not support on/off/etc. before suggest that it may be targeting YAML 1.2(.2?).

Serializing these words with quotes is backwards compatible, however if we start to deserialize them as bool this may be breaking to consumers of `serde-yaml`. I would suggest to consider either

1. We introduce some kind of `YamlVersion` enum and default to `YamlVersion::V1_2`, which foregoes matching the on/off/etc. words
2. We pass a flag to `parse_bool()` during serialization so that we serialize treating these words as bool but don't during deserialization

</details>